### PR TITLE
ignore spaces in reading answers

### DIFF
--- a/ios/AnswerChecker.m
+++ b/ios/AnswerChecker.m
@@ -109,6 +109,7 @@ TKMAnswerCheckerResult CheckAnswer(NSString **answer,
   switch (taskType) {
     case kTKMTaskTypeReading:
       *answer = [*answer stringByReplacingOccurrencesOfString:@"n" withString:@"ん"];
+      *answer = [*answer stringByReplacingOccurrencesOfString:@" " withString:@""];
       if (IsAsciiPresent(*answer)) {
         return kTKMAnswerContainsInvalidCharacters;
       }


### PR DESCRIPTION
i sometimes hit the space bar by accident, inserting random spaces into the reading answer, this should strip out any space before doing the check.

this is assumes there is never any space required in any reading answers (not sure if that's the case)