### PR TITLE
Katakana can now be typed into the Textfield

### DIFF
--- a/ios/TKMKanaInput.m
+++ b/ios/TKMKanaInput.m
@@ -323,6 +323,22 @@ static void EnsureInitialised() {
   });
 }
 
+NSString *convertHiraganaToKatakana(NSString *string) {
+    int differenceHiraganaKatakana = u'ア' - u'あ';
+    
+    unichar stringBuffer[string.length];
+    [string getCharacters:stringBuffer];
+    
+    for (int i = 0; i < string.length; ++i) {
+        // if the character is in Hiragana Unicode Block
+        if (stringBuffer[i] >= u'\u3040' && stringBuffer[i] <= u'\u309f') {
+            stringBuffer[i] = stringBuffer[i] + differenceHiraganaKatakana;
+        }
+    }
+    
+    return [[NSString alloc] initWithCharacters:stringBuffer length:string.length];
+}
+
 NSString *TKMConvertKanaText(NSString *input) {
   EnsureInitialised();
   

--- a/ios/TKMKanaInput.m
+++ b/ios/TKMKanaInput.m
@@ -413,14 +413,24 @@ replacementString:(NSString *)string {
   if (range.location > 0 && string.length == 1) {
     unichar newChar = [string characterAtIndex:0];
     unichar lastChar = [textField.text characterAtIndex:range.location - 1];
+      
+    BOOL lastCharWasUppercase = [[NSCharacterSet uppercaseLetterCharacterSet] characterIsMember: lastChar];
+    
+    newChar = tolower(newChar);
+    lastChar = tolower(lastChar);
   
     // Test for sokuon.
     if (![kN characterIsMember:newChar] &&
         newChar == lastChar &&
         [kConsonants characterIsMember:newChar] &&
         [kConsonants characterIsMember:lastChar]) {
+    
+      NSString *replacementString = @"っ";
+      if (lastCharWasUppercase) {
+        replacementString = convertHiraganaToKatakana(replacementString);
+      }
       textField.text = [textField.text stringByReplacingCharactersInRange:NSMakeRange(range.location - 1, 1)
-                                                               withString:@"っ"];
+                                                               withString:replacementString];
       return YES;
     }
   
@@ -428,8 +438,12 @@ replacementString:(NSString *)string {
     if (newChar != 'n' &&
         [kN characterIsMember:lastChar] &&
         ![kCanFollowN characterIsMember:newChar]) {
+      NSString *replacementString = @"ん";
+      if (lastCharWasUppercase) {
+        replacementString = convertHiraganaToKatakana(replacementString);
+      }
       textField.text = [textField.text stringByReplacingCharactersInRange:NSMakeRange(range.location - 1, 1)
-                                                               withString:@"ん"];
+                                                               withString:replacementString];
       return YES;
     }
   }
@@ -442,8 +456,16 @@ replacementString:(NSString *)string {
     NSRange replacementRange = NSMakeRange(range.location - i, i);
     NSString *text = [NSString stringWithFormat:@"%@%@",
                       [textField.text substringWithRange:replacementRange], string];
+      
+    BOOL firstCharacterIsUppercase = [[NSCharacterSet uppercaseLetterCharacterSet]
+                                      characterIsMember: [text characterAtIndex:0]];
+    text = [text lowercaseString];
+      
     NSString *replacement = kReplacements[text];
     if (replacement) {
+      if (firstCharacterIsUppercase) {
+        replacement = convertHiraganaToKatakana(replacement);
+      }
       textField.text = [textField.text stringByReplacingCharactersInRange:replacementRange
                                                                withString:replacement];
       return NO;

--- a/ios/Tests/TKMKanaInputTest.m
+++ b/ios/Tests/TKMKanaInputTest.m
@@ -1,0 +1,141 @@
+//
+//  KTMKanaTest.m
+//  Tests
+//
+//  Created by Henri on 04.10.18.
+//  Copyright © 2018 David Sansome. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "../TKMKanaInput.h"
+#import "../TKMKanaInput.m"
+
+@interface StubUITextField : UITextField
+@end
+
+@implementation StubUITextField
+@end
+
+@interface StubUITextFieldDelegate : NSObject <UITextFieldDelegate>
+@end
+
+@implementation StubUITextFieldDelegate
+
+@end
+
+@interface TKMKanaInputTest : XCTestCase
+
+@end
+
+@implementation TKMKanaInputTest
+static NSCharacterSet *_tsuConsonants;
+static NSArray *_tsuConsonantsArray;
+TKMKanaInput *_kanaInput;
+UITextField *_stub;
+
+// TODO: I don't know how memory management in objective-c works...is it ok to return a NSArray* ?
++ (NSArray*)getCharactersFromCharacterSet:(NSCharacterSet*)charset {
+    NSMutableArray *array = [NSMutableArray array];
+    for (int plane = 0; plane <= 16; plane++) {
+        if ([charset hasMemberInPlane:plane]) {
+            UTF32Char c;
+            for (c = plane << 16; c < (plane+1) << 16; c++) {
+                if ([charset longCharacterIsMember:c]) {
+                    UTF32Char c1 = OSSwapHostToLittleInt32(c); // To make it byte-order safe
+                    NSString *s = [[NSString alloc] initWithBytes:&c1 length:4 encoding:NSUTF32LittleEndianStringEncoding];
+                    [array addObject:s];
+                }
+            }
+        }
+    }
+    return array;
+}
+
++ (void)setUp {
+    // Put setup code here. This method is called before the invocation of all test methods in the class.
+    
+    //tsuConsonants = kConsonants - kN
+    NSMutableCharacterSet *tsuConsonants = [[kN invertedSet] mutableCopy];
+    [tsuConsonants formIntersectionWithCharacterSet:kConsonants];
+    
+    _tsuConsonants = tsuConsonants;
+    _tsuConsonantsArray = [TKMKanaInputTest getCharactersFromCharacterSet:_tsuConsonants];
+}
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    StubUITextFieldDelegate *delegate = [[StubUITextFieldDelegate alloc] init];
+    _kanaInput = [[TKMKanaInput alloc] initWithDelegate:delegate];
+    _kanaInput.enabled = true;
+    
+    _stub = [[StubUITextField alloc] init];
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testShouldChangeCharactersInRange1 {
+    // when the _kanaInput is disabled shouldChangeCharactersInRange should return true and the text should be unchanged
+    
+    NSString *text = [_stub.text copy];
+    
+    _kanaInput.enabled = false;
+    BOOL returnValue = [_kanaInput textField:_stub shouldChangeCharactersInRange:NSMakeRange(0, 0) replacementString:@""];
+    
+    XCTAssertTrue(returnValue);
+    XCTAssertEqualObjects(text, _stub.text);
+}
+
+- (void)testShouldChangeCharactersInRange2 {
+    // when the length of the Range is greater 0 shouldChangeCharactersInRange should return true and the text should be unchanged
+    
+    NSString *text = [_stub.text copy];
+    
+    BOOL returnValue = [_kanaInput textField:_stub shouldChangeCharactersInRange:NSMakeRange(0, 3) replacementString:@""];
+    
+    XCTAssertTrue(returnValue);
+    XCTAssertEqualObjects(text, _stub.text);
+}
+
+- (void)testShouldChangeCharactersInRange3 {
+    // when there is a consonant and you type the same consonant it should be replaced by っ and the returnValue should be true
+    
+    for(NSString *consonant in _tsuConsonantsArray) {
+        _stub.text = consonant;
+        
+        BOOL returnValue = [_kanaInput textField:_stub shouldChangeCharactersInRange:NSMakeRange(1, 0) replacementString:consonant];
+        
+        XCTAssertTrue(returnValue);
+        XCTAssertEqualObjects(@"っ", _stub.text);
+    }
+}
+
+- (void)testShouldChangeCharactersInRange4 {
+    // when there is a n or m and you type a consonant it should be replaced by ん and the returnValue should be true
+    
+    NSArray *kNArray = [TKMKanaInputTest getCharactersFromCharacterSet:kN];
+    
+    for(NSString *consonant in _tsuConsonantsArray) {
+        for(NSString *nm in kNArray) {
+            _stub.text = nm;
+            
+            BOOL returnValue = [_kanaInput textField:_stub shouldChangeCharactersInRange:NSMakeRange(1, 0) replacementString:consonant];
+            
+            XCTAssertTrue(returnValue);
+            XCTAssertEqualObjects(@"ん", _stub.text);
+        }
+    }
+}
+
+
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/ios/Tests/TKMKanaInputTest.m
+++ b/ios/Tests/TKMKanaInputTest.m
@@ -76,6 +76,14 @@ UITextField *_stub;
     // Put teardown code here. This method is called after the invocation of each test method in the class.
 }
 
+- (void)testkReplacementsContainsOnlyValidCombinations {
+    for(NSString *key1 in [kReplacements keyEnumerator]) {
+        for(NSString *key2 in [kReplacements keyEnumerator]) {
+            XCTAssertFalse(key1 != key2 && [key1 hasPrefix:key2]);
+        }
+    }
+}
+
 - (void)testShouldChangeCharactersInRange1 {
     // when the _kanaInput is disabled shouldChangeCharactersInRange should return true and the text should be unchanged
     
@@ -148,12 +156,5 @@ UITextField *_stub;
     }
 }
 
-- (void)testkReplacementsContainsOnlyValidCombinations {
-    for(NSString *key1 in [kReplacements keyEnumerator]) {
-        for(NSString *key2 in [kReplacements keyEnumerator]) {
-            XCTAssertFalse(key1 != key2 && [key1 hasPrefix:key2]);
-        }
-    }
-}
 
 @end

--- a/ios/Tests/TKMKanaInputTest.m
+++ b/ios/Tests/TKMKanaInputTest.m
@@ -129,13 +129,31 @@ UITextField *_stub;
     }
 }
 
+- (void)testShouldChangeCharactersInRange5 {
+    // when there is the start of a pattern and you type the last letter of the pattern it should be replaced by the given replacement and the returnValue should be false
+    
+    for(NSString *replacement in [kReplacements keyEnumerator]) {
+        // this pattern is checked by another case...for this function it doesn't matter if it is in the kReplacements CharacterSet
+        if([replacement isEqualToString:@"n "]) {
+            continue;
+        }
+        
+        NSString *lastReplacementCharacter = [replacement substringFromIndex:replacement.length - 1];
+        
+        _stub.text = [replacement substringToIndex:replacement.length - 1];
+        
+        BOOL returnValue = [_kanaInput textField:_stub shouldChangeCharactersInRange:NSMakeRange(_stub.text.length, 0) replacementString: lastReplacementCharacter];
+        XCTAssertFalse(returnValue);
+        XCTAssertEqualObjects(kReplacements[replacement], _stub.text);
+    }
+}
 
-
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
+- (void)testkReplacementsContainsOnlyValidCombinations {
+    for(NSString *key1 in [kReplacements keyEnumerator]) {
+        for(NSString *key2 in [kReplacements keyEnumerator]) {
+            XCTAssertFalse(key1 != key2 && [key1 hasPrefix:key2]);
+        }
+    }
 }
 
 @end

--- a/ios/Tests/TKMKanaInputTest.m
+++ b/ios/Tests/TKMKanaInputTest.m
@@ -170,7 +170,7 @@ UITextField *_stub;
         BOOL returnValue = [_kanaInput textField:_stub shouldChangeCharactersInRange:NSMakeRange(1, 0) replacementString:uppercaseConsonant];
         
         XCTAssertTrue(returnValue);
-        XCTAssertEqual(@"ッ", _stub.text);
+        XCTAssertEqualObjects(@"ッ", _stub.text);
     }
 }
 
@@ -203,15 +203,27 @@ UITextField *_stub;
             continue;
         }
         
-        NSString *lastReplacementCharacter = [replacement substringFromIndex:replacement.length - 1];
+        NSString *capitalizedReplacement = [replacement capitalizedString];
+        
+        NSString *lastReplacementCharacter = [capitalizedReplacement substringFromIndex:capitalizedReplacement.length - 1];
         
         
-        _stub.text = [[replacement substringToIndex:replacement.length - 1] capitalizedString];
+        _stub.text = [capitalizedReplacement substringToIndex:capitalizedReplacement.length - 1];
         
         BOOL returnValue = [_kanaInput textField:_stub shouldChangeCharactersInRange:NSMakeRange(_stub.text.length, 0) replacementString: lastReplacementCharacter];
         XCTAssertFalse(returnValue);
-        XCTAssertEqualObjects(kReplacements[replacement], _stub.text);
+        XCTAssertEqualObjects(convertHiraganaToKatakana(kReplacements[replacement]), _stub.text);
     }
+}
+
+- (void)testConvertHiraganaToKatakana1 {
+    // hopefully I got all the combinations :D
+    NSString *hiraganaInput = @"あいうえおかきくけこきゃきゅきょさしすせそしゃしゅしょたちつてとちゃちゅちょなにぬねのにゃにゅにょはひふへほひゃひゅひょまみむめもみゃみゅみょやゆよらりるれろりゃりゅりょわゐゑをんがぎぐげごぎゃぎゅぎょざじずぜぞじゃじゅじょだぢづでどぢゃぢゅぢょばびぶべぼびゃびゅびょぱぴぷぺぽぴゃぴゅぴょっ";
+    
+    NSString *katakanaOutput = @"アイウエオカキクケコキャキュキョサシスセソシャシュショタチツテトチャチュチョナニヌネノニャニュニョハヒフヘホヒャヒュヒョマミムメモミャミュミョヤユヨラリルレロリャリュリョワヰヱヲンガギグゲゴギャギュギョザジズゼゾジャジュジョダヂヅデドヂャヂュヂョバビブベボビャビュビョパピプペポピャピュピョッ";
+    NSString *converted = convertHiraganaToKatakana(hiraganaInput);
+    
+    XCTAssertEqualObjects(katakanaOutput,converted);
 }
 
 @end


### PR DESCRIPTION
I added the capability to type in Katakana into the review textfield. It is not 100% equivalent with the WaniKani input (e.g. my implementation converts Nn to ン, WaniKani does not). I also added some simple tests for this functionality.