### PR TITLE
Adds `mkdir data` to README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You'll need:
 
 Run the scraper:
 
+    mkdir data
     go run cmd/scrape/main.go --api-token [Your API token] --cookie [Your HTTP cookie]
 
 This will take an hour or so to download everything.  It stores its output in the ```data``` directory (change this with ```--out```).  You can stop it and start it again and it will pick up from where it left off.


### PR DESCRIPTION
The `data` folder probably doesn’t exist the first time you follow the instructions. In that case the subsequent command will fail:
```
panic: directory data does not exist

goroutine 1 [running]:
github.com/davidsansome/tsurukame/utils.Must(...)
	/Users/play/go/src/github.com/davidsansome/tsurukame/utils/utils.go:9
main.main()
	/Users/play/Desktop/tsurukame/cmd/scrape/main.go:49 +0x174
exit status 2
```