### PR TITLE
Review notifications

### DIFF
--- a/ios/AppDelegate.m
+++ b/ios/AppDelegate.m
@@ -150,7 +150,7 @@
         nextDateAfterDate:[NSDate date]
              matchingUnit:NSCalendarUnitMinute
                     value:0
-                  options:NSCalendarMatchNextTime | NSCalendarMatchStrictly];
+                  options:NSCalendarMatchNextTime];
     NSTimeInterval startInterval = [startDate timeIntervalSinceNow];
     int cumulativeReviews = reviewCount;
     for (int hour = 0; hour < upcomingReviews.count; hour++) {

--- a/ios/AppDelegate.m
+++ b/ios/AppDelegate.m
@@ -167,6 +167,7 @@
       }
       NSString *identifier = [NSString stringWithFormat:@"badge-%d", hour];
       UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+      content.body = [NSString stringWithFormat:@"%d review%@ available", cumulativeReviews, cumulativeReviews == 1 ? @"" : @"s"];
       content.badge = @(cumulativeReviews);
       UNNotificationTrigger *trigger =
           [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:triggerTimeInterval


### PR DESCRIPTION
Right now, the only thing keeping Allicrab installed on my phone is the notifications when new reviews or lessons are available. This PR adds local notifications at the same time as the badge number updates to show how many reviews are available.

Closes #64.