### PR TITLE
Add a setting to hide old mnemonics from radicals.

### DIFF
--- a/ios/SettingsViewController.m
+++ b/ios/SettingsViewController.m
@@ -110,6 +110,12 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
                                                         on:UserDefaults.enableCheats
                                                     target:self
                                                     action:@selector(enableCheatsSwitchChanged:)]];
+  [model addItem:[[TKMSwitchModelItem alloc] initWithStyle:UITableViewCellStyleSubtitle
+                                                     title:@"Show old mnemonics"
+                                                  subtitle:@"Display old mnemonics alongside new ones"
+                                                        on:UserDefaults.showOldMnemonic
+                                                    target:self
+                                                    action:@selector(showOldMnemonicChanged:)]];
 
   [model addSection:@"Audio"];
   [model addItem:[[TKMSwitchModelItem alloc]
@@ -222,6 +228,10 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
 
 - (void)enableCheatsSwitchChanged:(UISwitch *)switchView {
   UserDefaults.enableCheats = switchView.on;
+}
+
+- (void)showOldMnemonicChanged:(UISwitch *)switchView {
+  UserDefaults.showOldMnemonic = switchView.on;
 }
 
 - (void)playAudioAutomaticallySwitchChanged:(UISwitch *)switchView {

--- a/ios/UserDefaults.h
+++ b/ios/UserDefaults.h
@@ -47,6 +47,7 @@ DECLARE_BOOL(groupMeaningReading);
 DECLARE_BOOL(meaningFirst);
 DECLARE_BOOL(showAnswerImmediately);
 DECLARE_BOOL(enableCheats);
+DECLARE_BOOL(showOldMnemonic)
 
 // Offline audio.
 DECLARE_BOOL(playAudioAutomatically);

--- a/ios/UserDefaults.m
+++ b/ios/UserDefaults.m
@@ -70,6 +70,7 @@ DEFINE_BOOL(groupMeaningReading, setGroupMeaningReading, NO);
 DEFINE_BOOL(meaningFirst, setMeaningFirst, YES);
 DEFINE_BOOL(showAnswerImmediately, setShowAnswerImmediately, YES);
 DEFINE_BOOL(enableCheats, setEnableCheats, YES);
+DEFINE_BOOL(showOldMnemonic, setShowOldMnemonic, YES);
 
 DEFINE_BOOL(playAudioAutomatically, setPlayAudioAutomatically, NO);
 DEFINE_OBJECT(NSSet<NSString *>, installedAudioPackages, setInstalledAudioPackages);

--- a/ios/proto/Wanikani+Convenience.m
+++ b/ios/proto/Wanikani+Convenience.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "Wanikani+Convenience.h"
+#import "UserDefaults.h"
 
 #import <UIKit/UIKit.h>
 
@@ -137,7 +138,8 @@ NSString *TKMDetailedSRSStageName(int srsStage) {
 - (NSString *)commaSeparatedMeanings {
   NSMutableArray<NSString *> *strings = [NSMutableArray array];
   for (TKMMeaning *meaning in self.meaningsArray) {
-    if (meaning.type != TKMMeaning_Type_Blacklist) {
+    if (meaning.type != TKMMeaning_Type_Blacklist &&
+      (meaning.type != TKMMeaning_Type_AuxiliaryWhitelist || !self.hasRadical || UserDefaults.showOldMnemonic)) {
       [strings addObject:meaning.meaning];
     }
   }


### PR DESCRIPTION
I recently started using WaniKani and Tsurukame. I noticed that there have been changes to the mnemonics for radicals over the years and old mnemonics are still shown in the app, possibly for existing users. While learning new radicals as a new user, I can't help but also look at the old mnemonics and I tend to get confused.

In this PR I am adding a new setting "Show Old Mnemonics" that is enabled by default which keeps the current behavior of the app. When disabled it will hide the old meanings both from the levels view as well as the detail view. I did not make them invalid as answers because it is only meant to be a visual change. It will also ensure that future updates to radical mnemonics won't disrupt current users.

## Test Plan
Click this image for a [video](https://youtu.be/soIZ85Mu-CQ) showing this feature:
[![test video](https://img.youtube.com/vi/soIZ85Mu-CQ/0.jpg)](https://youtu.be/soIZ85Mu-CQ)

Finally, I just wanna thank you for building such a high quality app, making it free and open source to contribute. Tsurukame is one of my favorite iOS apps. Thank you!