### PR TITLE
Advance on "return" after wrong answer

### DIFF
--- a/ios/ReviewViewController.mm
+++ b/ios/ReviewViewController.mm
@@ -280,6 +280,10 @@ class AnimationContext {
   return (int)_activeQueue.count;
 }
 
+- (BOOL)canBecomeFirstResponder {
+  return true;
+}
+
 #pragma mark - UIViewController
 
 - (void)viewDidLoad {


### PR DESCRIPTION
This PR resolves #95 by allowing ReviewViewController to become the first responder itself. That way, after the `answerField` resigns first responder on line 644, the ReviewViewController can still respond to the return key and move on to the next question.

https://github.com/indirect/tsurukame/blob/74b9c80ab058a45bd0e6aa02ef6434ef810f0d60/ios/ReviewViewController.mm#L644