### PR TITLE
Add ability to customize lessons

### DIFF
--- a/ios/LessonOrderViewController.h
+++ b/ios/LessonOrderViewController.h
@@ -1,0 +1,19 @@
+// Copyright 2018 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+@interface LessonOrderViewController : UITableViewController
+
+@end

--- a/ios/LessonOrderViewController.m
+++ b/ios/LessonOrderViewController.m
@@ -1,0 +1,61 @@
+// Copyright 2018 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "LessonOrderViewController.h"
+#import "UserDefaults.h"
+
+@interface LessonOrderViewController ()
+@end
+
+@implementation LessonOrderViewController
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  if (![UserDefaults.lessonOrder count]) {
+    UserDefaults.lessonOrder = [[NSMutableArray alloc] initWithObjects:@"Radicals",@"Kanji",@"Vocabulary",nil];
+  }
+
+  self.tableView.editing = YES;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+  return UserDefaults.lessonOrder.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+  UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"cellIdentifier"];
+  if(cell == nil) {
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"cellIdentifier"];  
+  }
+  cell.textLabel.text = [UserDefaults.lessonOrder objectAtIndex:indexPath.row];
+  return cell;
+}
+
+- (UITableViewCellEditingStyle)tableView:(UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath {
+  return UITableViewCellEditingStyleNone;
+}
+
+- (BOOL)tableView:(UITableView *)tableView shouldIndentWhileEditingRowAtIndexPath:(NSIndexPath *)indexPath {
+  return NO;
+}
+
+- (void)tableView:(UITableView *)tableView moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath {
+  NSMutableArray *copy = [[NSMutableArray alloc] initWithArray:UserDefaults.lessonOrder copyItems:YES];
+  NSString *item = [copy objectAtIndex:sourceIndexPath.row];
+  [copy removeObject:item];
+  [copy insertObject:item atIndex:destinationIndexPath.row];
+  UserDefaults.lessonOrder = copy;
+}
+
+@end

--- a/ios/Main.storyboard
+++ b/ios/Main.storyboard
@@ -839,6 +839,7 @@
                         <segue destination="uj2-VH-hcW" kind="show" identifier="reviewOrder" id="7Yf-CB-TUU"/>
                         <segue destination="AG2-Tf-RDu" kind="show" identifier="offlineAudio" id="EkU-M7-aeu"/>
                         <segue destination="QeO-rY-q75" kind="show" identifier="fonts" id="l0d-dJ-or1"/>
+                        <segue destination="B5Q-PH-hTQ" kind="show" identifier="lessonOrder" id="gQL-Z8-EnR"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UFO-Ke-JcM" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1094,6 +1095,81 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="BnI-lh-nSF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1821.5999999999999" y="-493.40329835082463"/>
+        </scene>
+        <!--Lesson order-->
+        <scene sceneID="BjM-im-n92">
+            <objects>
+                <tableViewController title="Lesson order" id="B5Q-PH-hTQ" userLabel="Lesson order" customClass="LessonOrderViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ajq-lt-z5I">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <sections>
+                            <tableViewSection id="Djf-HP-Gkg">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="10" textLabel="Cm6-A9-ZLv" style="IBUITableViewCellStyleDefault" id="Xjr-zw-H4e">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Xjr-zw-H4e" id="46I-6E-vUO">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Radicals" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Cm6-A9-ZLv">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="10" textLabel="1Io-ok-GMc" style="IBUITableViewCellStyleDefault" id="B6y-X6-EEl">
+                                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="B6y-X6-EEl" id="Ttq-uc-Pq5">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Kanji" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="1Io-ok-GMc">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="10" textLabel="03H-UN-ACa" style="IBUITableViewCellStyleDefault" id="pHq-t6-uso">
+                                        <rect key="frame" x="0.0" y="88" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pHq-t6-uso" id="xJK-Z9-9Hh">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Vocabulary" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="03H-UN-ACa">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="B5Q-PH-hTQ" id="bJ8-kJ-wTK"/>
+                            <outlet property="delegate" destination="B5Q-PH-hTQ" id="PWC-ic-zJh"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2Ej-cY-XFU" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-92" y="-1155"/>
         </scene>
     </scenes>
     <resources>

--- a/ios/ReviewItem.h
+++ b/ios/ReviewItem.h
@@ -32,6 +32,8 @@ typedef NS_ENUM(NSInteger, TKMTaskType) {
 + (NSArray<ReviewItem *> *)assignmentsReadyForLesson:(NSArray<TKMAssignment *> *)assignments
                                           dataLoader:(DataLoader *)dataLoader;
 
+- (NSUInteger)getSubjectTypeIndex:(TKMSubject_Type)type;
+
 - (instancetype)initFromAssignment:(TKMAssignment *)assignment NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/ios/ReviewItem.m
+++ b/ios/ReviewItem.m
@@ -49,6 +49,17 @@
   return ret;
 }
 
+- (NSUInteger)getSubjectTypeIndex:(TKMSubject_Type)type {
+  if (type == TKMSubject_Type_Radical) {
+    return [UserDefaults.lessonOrder indexOfObject:@"Radicals"];
+  } else if (type == TKMSubject_Type_Kanji) {
+    return [UserDefaults.lessonOrder indexOfObject:@"Kanji"];
+  } else if (type == TKMSubject_Type_Vocabulary) {
+    return [UserDefaults.lessonOrder indexOfObject:@"Vocabulary"];
+  }
+  return 0;
+}
+
 - (instancetype)initFromAssignment:(TKMAssignment *)assignment {
   if (self = [super init]) {
     _assignment = assignment;
@@ -66,10 +77,20 @@
     return UserDefaults.prioritizeCurrentLevel ? NSOrderedAscending : NSOrderedDescending ;
   }
 
-  if (self.assignment.subjectType < other.assignment.subjectType) {
-    return NSOrderedAscending;
-  } else if (self.assignment.subjectType > other.assignment.subjectType) {
-    return NSOrderedDescending;
+  if ([UserDefaults.lessonOrder count]) {
+    NSUInteger selfIndex = [self getSubjectTypeIndex:self.assignment.subjectType];
+    NSUInteger otherIndex = [self getSubjectTypeIndex:other.assignment.subjectType];
+    if (selfIndex < otherIndex) {
+      return NSOrderedAscending;
+    } else if (selfIndex > otherIndex) {
+      return NSOrderedDescending;
+    }
+  } else {
+    if (self.assignment.subjectType < other.assignment.subjectType) {
+      return NSOrderedAscending;
+    } else if (self.assignment.subjectType > other.assignment.subjectType) {
+      return NSOrderedDescending;
+    }
   }
 
   if (self.assignment.subjectId < other.assignment.subjectId) {

--- a/ios/ReviewItem.m
+++ b/ios/ReviewItem.m
@@ -14,6 +14,7 @@
 
 #import "ReviewItem.h"
 #import "DataLoader.h"
+#import "UserDefaults.h"
 #import "proto/Wanikani+Convenience.h"
 
 @implementation ReviewItem
@@ -59,20 +60,25 @@
 }
 
 - (NSComparisonResult)compareForLessons:(ReviewItem *)other {
-#define COMPARE(field)            \
-  if (self.field < other.field) { \
-    return NSOrderedAscending;    \
-  }                               \
-  if (self.field > other.field) { \
-    return NSOrderedDescending;   \
+  if (self.assignment.level < other.assignment.level) {
+    return UserDefaults.prioritizeCurrentLevel ? NSOrderedDescending : NSOrderedAscending;
+  } else if (self.assignment.level > other.assignment.level) {
+    return UserDefaults.prioritizeCurrentLevel ? NSOrderedAscending : NSOrderedDescending ;
   }
 
-  COMPARE(assignment.level);
-  COMPARE(assignment.subjectType);
-  COMPARE(assignment.subjectId);
-  return NSOrderedSame;
+  if (self.assignment.subjectType < other.assignment.subjectType) {
+    return NSOrderedAscending;
+  } else if (self.assignment.subjectType > other.assignment.subjectType) {
+    return NSOrderedDescending;
+  }
 
-#undef COMPARE
+  if (self.assignment.subjectId < other.assignment.subjectId) {
+    return NSOrderedAscending;
+  } else if (self.assignment.subjectId > other.assignment.subjectId) {
+    return NSOrderedDescending;
+  }
+
+  return NSOrderedSame;
 }
 
 - (void)reset {

--- a/ios/SettingsViewController.m
+++ b/ios/SettingsViewController.m
@@ -74,6 +74,14 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
                                                         on:UserDefaults.prioritizeCurrentLevel
                                                     target:self
                                                     action:@selector(prioritizeCurrentLevelChanged:)]];
+  [model
+      addItem:[[TKMBasicModelItem alloc] initWithStyle:UITableViewCellStyleValue1
+                                                 title:@"Lesson order"
+                                              subtitle:self.lessonOrderValueText
+                                         accessoryType:UITableViewCellAccessoryDisclosureIndicator
+                                                target:self
+                                                action:@selector(didTapLessonOrder:)]];
+
   [model addSection:@"Reviews"];
   [model
       addItem:[[TKMBasicModelItem alloc] initWithStyle:UITableViewCellStyleValue1
@@ -183,6 +191,10 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
 
   _model = model;
   [model reloadTable];
+}
+
+- (NSString *)lessonOrderValueText {
+  return [UserDefaults.lessonOrder componentsJoinedByString:@", "];
 }
 
 - (NSString *)reviewOrderValueText {
@@ -328,6 +340,10 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
     }
     _notificationHandler(granted);
   }];
+}
+
+- (void)didTapLessonOrder:(TKMBasicModelItem *)item {
+  [self performSegueWithIdentifier:@"lessonOrder" sender:self];
 }
 
 - (void)didTapReviewOrder:(TKMBasicModelItem *)item {

--- a/ios/SettingsViewController.m
+++ b/ios/SettingsViewController.m
@@ -67,6 +67,13 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
                                                     target:self
                                                     action:@selector(badgingSwitchChanged:)]];
 
+  [model addSection:@"Lessons"];
+  [model addItem:[[TKMSwitchModelItem alloc] initWithStyle:UITableViewCellStyleSubtitle
+                                                     title:@"Prioritize current level"
+                                                  subtitle:@"Teach items from the current level first"
+                                                        on:UserDefaults.prioritizeCurrentLevel
+                                                    target:self
+                                                    action:@selector(prioritizeCurrentLevelChanged:)]];
   [model addSection:@"Reviews"];
   [model
       addItem:[[TKMBasicModelItem alloc] initWithStyle:UITableViewCellStyleValue1
@@ -215,6 +222,10 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
 
 - (void)animatePlusOneSwitchChanged:(UISwitch *)switchView {
   UserDefaults.animatePlusOne = switchView.on;
+}
+
+- (void)prioritizeCurrentLevelChanged:(UISwitch *)switchView {
+  UserDefaults.prioritizeCurrentLevel = switchView.on;
 }
 
 - (void)groupMeaningReadingSwitchChanged:(UISwitch *)switchView {

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3DA8BAFC224C9580009E925B /* LessonOrderViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DA8BAFB224C9580009E925B /* LessonOrderViewController.m */; };
 		630ADB6921F816E400BC9801 /* MMDrawerBarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 630ADB6021F816E400BC9801 /* MMDrawerBarButtonItem.m */; };
 		630ADB6A21F816E400BC9801 /* UIViewController+MMDrawerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 630ADB6121F816E400BC9801 /* UIViewController+MMDrawerController.m */; };
 		630ADB6B21F816E400BC9801 /* MMDrawerController.m in Sources */ = {isa = PBXBuildFile; fileRef = 630ADB6221F816E400BC9801 /* MMDrawerController.m */; };
@@ -287,6 +288,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3DA8BAFA224C957F009E925B /* LessonOrderViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LessonOrderViewController.h; sourceTree = "<group>"; };
+		3DA8BAFB224C9580009E925B /* LessonOrderViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LessonOrderViewController.m; sourceTree = "<group>"; };
 		630ADB6021F816E400BC9801 /* MMDrawerBarButtonItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMDrawerBarButtonItem.m; sourceTree = "<group>"; };
 		630ADB6121F816E400BC9801 /* UIViewController+MMDrawerController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+MMDrawerController.m"; sourceTree = "<group>"; };
 		630ADB6221F816E400BC9801 /* MMDrawerController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MMDrawerController.m; sourceTree = "<group>"; };
@@ -1007,6 +1010,8 @@
 				63C42A3621B6A290008CA938 /* FontScreenshotterUITests.xctest */,
 				63CAAB0F1FD7FAC500E09DA1 /* Frameworks */,
 				63EEFEC21FC45CB10070C05F /* Info.plist */,
+				3DA8BAFA224C957F009E925B /* LessonOrderViewController.h */,
+				3DA8BAFB224C9580009E925B /* LessonOrderViewController.m */,
 				63CAAB0A1FD2CBD900E09DA1 /* LaunchScreen.storyboard */,
 				637C12DC203D779D009E92DB /* LessonsPageControl.h */,
 				637C12DD203D779D009E92DB /* LessonsPageControl.m */,
@@ -1743,6 +1748,7 @@
 				633632EC201F3011006D582B /* LoginViewController.m in Sources */,
 				63CE766321F47100002A417B /* TKMReviewContainerViewController.m in Sources */,
 				630ADB6921F816E400BC9801 /* MMDrawerBarButtonItem.m in Sources */,
+				3DA8BAFC224C9580009E925B /* LessonOrderViewController.m in Sources */,
 				630ADD8C21FEB34C00BC9801 /* BarLineScatterCandleBubbleChartData.swift in Sources */,
 				63453E4920EF8C0500F20404 /* HNKCache.m in Sources */,
 				63CAAAEC1FC6E1D400E09DA1 /* GPBUnknownField.m in Sources */,

--- a/ios/UserDefaults.h
+++ b/ios/UserDefaults.h
@@ -40,6 +40,9 @@ DECLARE_BOOL(animateParticleExplosion);
 DECLARE_BOOL(animateLevelUpPopup);
 DECLARE_BOOL(animatePlusOne);
 
+// Lesson settings.
+DECLARE_BOOL(prioritizeCurrentLevel);
+
 // Review settings.
 DECLARE_ENUM(ReviewOrder, reviewOrder);
 DECLARE_OBJECT(NSSet<NSString *>, selectedFonts);

--- a/ios/UserDefaults.h
+++ b/ios/UserDefaults.h
@@ -42,6 +42,7 @@ DECLARE_BOOL(animatePlusOne);
 
 // Lesson settings.
 DECLARE_BOOL(prioritizeCurrentLevel);
+DECLARE_OBJECT(NSMutableArray<NSString *>, lessonOrder);
 
 // Review settings.
 DECLARE_ENUM(ReviewOrder, reviewOrder);

--- a/ios/UserDefaults.m
+++ b/ios/UserDefaults.m
@@ -64,6 +64,8 @@ DEFINE_BOOL(animateParticleExplosion, setAnimateParticleExplosion, YES);
 DEFINE_BOOL(animateLevelUpPopup, setAnimateLevelUpPopup, YES);
 DEFINE_BOOL(animatePlusOne, setAnimatePlusOne, YES);
 
+DEFINE_BOOL(prioritizeCurrentLevel, setPrioritizeCurrentLevel, NO);
+
 DEFINE_ENUM(ReviewOrder, reviewOrder, setReviewOrder, ReviewOrder_Random);
 DEFINE_OBJECT(NSSet<NSString *>, selectedFonts, setSelectedFonts);
 DEFINE_BOOL(groupMeaningReading, setGroupMeaningReading, NO);

--- a/ios/UserDefaults.m
+++ b/ios/UserDefaults.m
@@ -65,6 +65,7 @@ DEFINE_BOOL(animateLevelUpPopup, setAnimateLevelUpPopup, YES);
 DEFINE_BOOL(animatePlusOne, setAnimatePlusOne, YES);
 
 DEFINE_BOOL(prioritizeCurrentLevel, setPrioritizeCurrentLevel, NO);
+DEFINE_OBJECT(NSMutableArray<NSString *>, lessonOrder, setLessonOrder);
 
 DEFINE_ENUM(ReviewOrder, reviewOrder, setReviewOrder, ReviewOrder_Random);
 DEFINE_OBJECT(NSSet<NSString *>, selectedFonts, setSelectedFonts);


### PR DESCRIPTION
When leveling up, a lot of radicals, kanji and vocabulary become available at the same time. I usually tend to study ~5 new kanji per day which means that it often happens that I'll only get to study vocabulary once I am pretty close to leveling up again. I prefer to work myself through both kanji and vocabulary at the same time to reduce the load of new words towards the end of a level. Currently I use the wanikani website with a custom userscript but I'd prefer to use Tsurukame exclusively because of the much better user experience.

This PR adds two new options to customize which items are taught first in the lessons screen:
* Prioritize current level (default: disabled): When enabling this option, items from the current (highest) level will be shown before any lower levels.
* Sort by subject type (default: Radical, Kanji, Vocabulary): This option navigates to a new screen.

## Screenshot of the Settings view:
<img width="485" alt="Screen Shot 2019-03-27 at 23 55 48" src="https://user-images.githubusercontent.com/13352/55136659-457f8600-50ec-11e9-808a-beab12911936.png">

## Screenshot of the subject type sorting view:
<img width="485" alt="Screen Shot 2019-03-27 at 23 56 15" src="https://user-images.githubusercontent.com/13352/55136663-47e1e000-50ec-11e9-9e68-55cb913eda79.png">

*Note: I am not an Objective-C expert and most of the code I wrote here is the first time I did certain things, like creating a sortable TableView. Please let me know how I could do things better!*
