### PR TITLE
Persist SubjectCatalogueVC's show answers toggle

### DIFF
--- a/ios/SubjectCatalogueViewController.m
+++ b/ios/SubjectCatalogueViewController.m
@@ -16,6 +16,7 @@
 #import "DataLoader.h"
 #import "SubjectsByLevelViewController.h"
 #import "TKMServices.h"
+#import "UserDefaults.h"
 
 @interface SubjectCatalogueViewController () <UIPageViewControllerDataSource,
                                               UIPageViewControllerDelegate>
@@ -39,7 +40,7 @@
   self.dataSource = self;
 
   _answerSwitch = [[UISwitch alloc] init];
-  _answerSwitch.on = YES;
+  _answerSwitch.on = UserDefaults.subjectCatalogueViewShowAnswers;
   [_answerSwitch addTarget:self
                     action:@selector(answerSwitchChanged:)
           forControlEvents:UIControlEventValueChanged];
@@ -61,6 +62,7 @@
 
 - (void)answerSwitchChanged:(UISwitch *)sender {
   SubjectsByLevelViewController *vc = self.viewControllers.firstObject;
+  UserDefaults.subjectCatalogueViewShowAnswers = self.showAnswers;
   [vc setShowAnswers:self.showAnswers animated:true];
 }
 

--- a/ios/UserDefaults.h
+++ b/ios/UserDefaults.h
@@ -68,4 +68,7 @@ DECLARE_OBJECT(NSSet<NSString *>, installedAudioPackages);
 DECLARE_BOOL(notificationsAllReviews);
 DECLARE_BOOL(notificationsBadging);
 
+// Subject Catalogue View internal settings.
+DECLARE_BOOL(subjectCatalogueViewShowAnswers)
+
 @end

--- a/ios/UserDefaults.m
+++ b/ios/UserDefaults.m
@@ -114,4 +114,5 @@ DEFINE_OBJECT(NSSet<NSString *>, installedAudioPackages, setInstalledAudioPackag
 DEFINE_BOOL(notificationsAllReviews, setNotificationsAllReviews, NO);
 DEFINE_BOOL(notificationsBadging, setNotificationsBadging, YES);
 
+DEFINE_BOOL(subjectCatalogueViewShowAnswers, setSubjectCatalogueViewShowAnswers, YES);
 @end


### PR DESCRIPTION
This creates a user default that isn't actually used in the settings view. Instead it is controlled and read directly by the show answers toggle in the SubjectCatalogueViewController. I found myself not really wanting to see the answers and was wanting a way to have it be off when I enter the view!

I'm not sure if this breaks any kind of paradigm since I don't think there are any existing settings that persist outside of the settings view, so this might throw someone off. If it is preferred to be maintained from there, I can move it there, where it could be in a new section called "Catalogue" and named "Show answers by default" or something.

Let me know what you think!