### PR TITLE
Use font weights that iOS has

### DIFF
--- a/ios/Style.m
+++ b/ios/Style.m
@@ -103,9 +103,9 @@ UIFont *TKMJapaneseFont(CGFloat size) {
 }
 
 UIFont *TKMJapaneseFontLight(CGFloat size) {
-  return [UIFont fontWithName:[NSString stringWithFormat:@"%@ W2", kTKMJapaneseFontName] size:size];
+  return [UIFont fontWithName:[NSString stringWithFormat:@"%@ W3", kTKMJapaneseFontName] size:size];
 }
 
 UIFont *TKMJapaneseFontBold(CGFloat size) {
-  return [UIFont fontWithName:[NSString stringWithFormat:@"%@ W7", kTKMJapaneseFontName] size:size];
+  return [UIFont fontWithName:[NSString stringWithFormat:@"%@ W8", kTKMJapaneseFontName] size:size];
 }


### PR DESCRIPTION
This is a fix for #135, and switches to the font weights that are included with iOS according to both Apple's System Fonts page and real-life listing of available fonts as detailed in that issue's comments.