### PR TITLE
Add "Show remaining" screen showing level progress

### DIFF
--- a/ios/Client.m
+++ b/ios/Client.m
@@ -20,9 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 const char *kWanikaniSessionCookieName = "_wanikani_session";
 static const char *kURLBase = "https://api.wanikani.com/v2";
-static const char *kReviewProgressURL = "https://www.wanikani.com/json/progress";
-static const char *kLessonProgressURL = "https://www.wanikani.com/json/lesson/completed";
-static const char *kReviewSessionURL = "https://www.wanikani.com/review/session";
 static const char *kAccountURL = "https://www.wanikani.com/settings/account";
 static const char *kAccessTokenURL = "https://www.wanikani.com/settings/personal_access_tokens";
 static const char *kNewAccessTokenURL =

--- a/ios/Main.storyboard
+++ b/ios/Main.storyboard
@@ -353,8 +353,28 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="Jav-Y0-HDW" style="IBUITableViewCellStyleDefault" id="LSr-ta-wml">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="fQl-h7-gbR" style="IBUITableViewCellStyleDefault" id="6c7-a2-bvQ">
                                         <rect key="frame" x="0.0" y="541.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6c7-a2-bvQ" id="bCT-or-V8I">
+                                            <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Show remaining" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="fQl-h7-gbR">
+                                                    <rect key="frame" x="16" y="0.0" width="324" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="hY2-mK-T6s" kind="show" identifier="subjectsRemaining" id="ajb-xp-C3R"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="Jav-Y0-HDW" style="IBUITableViewCellStyleDefault" id="LSr-ta-wml">
+                                        <rect key="frame" x="0.0" y="585.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LSr-ta-wml" id="0od-eJ-5lG">
                                             <rect key="frame" x="0.0" y="0.0" width="341" height="43.5"/>
@@ -378,21 +398,21 @@
                             <tableViewSection headerTitle="Queued updates" id="d6d-VV-C0G">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="ZMS-Lu-tge" detailTextLabel="DCZ-py-fGX" style="IBUITableViewCellStyleSubtitle" id="nHm-ep-Nic">
-                                        <rect key="frame" x="0.0" y="641.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="685.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nHm-ep-Nic" id="M7S-MF-koV">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="You're up to date!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" enabled="NO" adjustsFontSizeToFit="NO" id="ZMS-Lu-tge">
-                                                    <rect key="frame" x="16" y="5" width="135" height="20.5"/>
+                                                    <rect key="frame" x="15" y="5" width="135" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" enabled="NO" adjustsFontSizeToFit="NO" id="DCZ-py-fGX">
-                                                    <rect key="frame" x="16" y="25.5" width="44" height="14.5"/>
+                                                    <rect key="frame" x="15" y="25.5" width="44" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <nil key="textColor"/>
@@ -510,6 +530,24 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nhW-65-6ah" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-727" y="834"/>
+        </scene>
+        <!--Subjects Remaining View Controller-->
+        <scene sceneID="6nk-dW-mbx">
+            <objects>
+                <tableViewController id="hY2-mK-T6s" customClass="SubjectsRemainingViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="zgK-r2-6R9">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <connections>
+                            <outlet property="dataSource" destination="hY2-mK-T6s" id="1JR-rS-UFA"/>
+                            <outlet property="delegate" destination="hY2-mK-T6s" id="rxs-um-fm7"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5O9-Gp-Lwf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-2012" y="833"/>
         </scene>
         <!--Review Menu View Controller-->
         <scene sceneID="vXK-vc-8c7">

--- a/ios/MainViewController.m
+++ b/ios/MainViewController.m
@@ -26,6 +26,7 @@
 #import "Style.h"
 #import "SubjectCatalogueViewController.h"
 #import "SubjectDetailsViewController.h"
+#import "SubjectsRemainingViewController.h"
 #import "TKMReviewContainerViewController.h"
 #import "TKMServices.h"
 #import "UpcomingReviewsChartController.h"
@@ -283,6 +284,9 @@ static void SetTableViewCellCount(UITableViewCell *cell, int count) {
   } else if ([segue.identifier isEqualToString:@"subjectCatalogue"]) {
     SubjectCatalogueViewController *vc =
         (SubjectCatalogueViewController *)segue.destinationViewController;
+    [vc setupWithServices:_services level:_services.localCachingClient.getUserInfo.level];
+  } else if ([segue.identifier isEqualToString:@"subjectsRemaining"]) {
+    SubjectsRemainingViewController *vc = segue.destinationViewController;
     [vc setupWithServices:_services level:_services.localCachingClient.getUserInfo.level];
   } else if ([segue.identifier isEqual:@"settings"]) {
     SettingsViewController *vc = (SettingsViewController *)segue.destinationViewController;

--- a/ios/MainViewController.m
+++ b/ios/MainViewController.m
@@ -287,7 +287,7 @@ static void SetTableViewCellCount(UITableViewCell *cell, int count) {
     [vc setupWithServices:_services level:_services.localCachingClient.getUserInfo.level];
   } else if ([segue.identifier isEqualToString:@"subjectsRemaining"]) {
     SubjectsRemainingViewController *vc = segue.destinationViewController;
-    [vc setupWithServices:_services level:_services.localCachingClient.getUserInfo.level];
+    [vc setupWithServices:_services];
   } else if ([segue.identifier isEqual:@"settings"]) {
     SettingsViewController *vc = (SettingsViewController *)segue.destinationViewController;
     [vc setupWithServices:_services];

--- a/ios/SubjectsRemainingViewController.h
+++ b/ios/SubjectsRemainingViewController.h
@@ -18,8 +18,6 @@
 
 @interface SubjectsRemainingViewController : UITableViewController
 
-@property(nonatomic, readonly) int level;
-
 - (void)setupWithServices:(TKMServices *)services;
 
 @end

--- a/ios/SubjectsRemainingViewController.h
+++ b/ios/SubjectsRemainingViewController.h
@@ -1,0 +1,25 @@
+// Copyright 2018 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <UIKit/UIKit.h>
+
+@class TKMServices;
+
+@interface SubjectsRemainingViewController : UITableViewController
+
+@property(nonatomic, readonly) int level;
+
+- (void)setupWithServices:(TKMServices *)services level:(int)level;
+
+@end

--- a/ios/SubjectsRemainingViewController.h
+++ b/ios/SubjectsRemainingViewController.h
@@ -20,6 +20,6 @@
 
 @property(nonatomic, readonly) int level;
 
-- (void)setupWithServices:(TKMServices *)services level:(int)level;
+- (void)setupWithServices:(TKMServices *)services;
 
 @end

--- a/ios/SubjectsRemainingViewController.m
+++ b/ios/SubjectsRemainingViewController.m
@@ -30,24 +30,23 @@
 
 @implementation SubjectsRemainingViewController {
   TKMServices *_services;
-  int _level;
   TKMTableModel *_model;
 }
 
-- (void)setupWithServices:(TKMServices *)services level:(int)level {
+- (void)setupWithServices:(TKMServices *)services {
   _services = services;
-  _level = level;
 }
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  self.navigationItem.title = [NSString stringWithFormat:@"Remaining in Level %d", _level];
+  int level = [_services.localCachingClient getUserInfo].level;
+  self.navigationItem.title = [NSString stringWithFormat:@"Remaining in Level %d", level];
 
   TKMMutableTableModel *model = [[TKMMutableTableModel alloc] initWithTableView:self.tableView];
   [model addSection:@"Radicals"];
   [model addSection:@"Kanji"];
 
-  for (TKMAssignment *assignment in [_services.localCachingClient getAssignmentsAtLevel:_level]) {
+  for (TKMAssignment *assignment in [_services.localCachingClient getAssignmentsAtUsersCurrentLevel]) {
     if (assignment.srsStage > 4) {
       continue;
     }

--- a/ios/SubjectsRemainingViewController.m
+++ b/ios/SubjectsRemainingViewController.m
@@ -1,0 +1,127 @@
+// Copyright 2018 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "SubjectsRemainingViewController.h"
+
+#import "DataLoader.h"
+#import "LocalCachingClient.h"
+#import "Style.h"
+#import "SubjectDetailsViewController.h"
+#import "TKMServices.h"
+#import "Tables/TKMListSeparatorItem.h"
+#import "Tables/TKMModelItem.h"
+#import "Tables/TKMSubjectModelItem.h"
+#import "Tables/TKMTableModel.h"
+#import "proto/Wanikani+Convenience.h"
+
+@interface SubjectsRemainingViewController () <TKMSubjectDelegate>
+@end
+
+@implementation SubjectsRemainingViewController {
+  TKMServices *_services;
+  int _level;
+  TKMTableModel *_model;
+}
+
+- (void)setupWithServices:(TKMServices *)services level:(int)level {
+  _services = services;
+  _level = level;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  self.navigationItem.title = [NSString stringWithFormat:@"Remaining in Level %d", _level];
+
+  TKMMutableTableModel *model = [[TKMMutableTableModel alloc] initWithTableView:self.tableView];
+  [model addSection:@"Radicals"];
+  [model addSection:@"Kanji"];
+
+  for (TKMAssignment *assignment in [_services.localCachingClient getAssignmentsAtLevel:_level]) {
+    if (assignment.srsStage > 4) {
+      continue;
+    }
+
+    TKMSubject *subject = [_services.dataLoader loadSubject:assignment.subjectId];
+    if (!subject || subject.subjectType == TKMSubject_Type_Vocabulary) {
+      continue;
+    }
+
+    int section = subject.subjectType - 1;
+    TKMSubjectModelItem *item = [[TKMSubjectModelItem alloc] initWithSubject:subject
+                                                                  assignment:assignment
+                                                                    delegate:self];
+    item.showLevelNumber = false;
+    item.showAnswers = false;
+    item.showRemaining = true;
+    if (!assignment.isReviewStage && !assignment.isLessonStage) {
+      item.gradientColors = TKMLockedGradient();
+    }
+    [model addItem:item toSection:section];
+  }
+
+  NSComparator comparator = ^NSComparisonResult(TKMSubjectModelItem *a, TKMSubjectModelItem *b) {
+    if (a.assignment.isReviewStage && !b.assignment.isReviewStage) return NSOrderedAscending;
+    if (!a.assignment.isReviewStage && b.assignment.isReviewStage) return NSOrderedDescending;
+    if (a.assignment.isLessonStage && !b.assignment.isLessonStage) return NSOrderedAscending;
+    if (!a.assignment.isLessonStage && b.assignment.isLessonStage) return NSOrderedDescending;
+    if (a.assignment.srsStage > b.assignment.srsStage) return NSOrderedAscending;
+    if (a.assignment.srsStage < b.assignment.srsStage) return NSOrderedDescending;
+    return NSOrderedSame;
+  };
+  [model sortSection:0 usingComparator:comparator];
+  [model sortSection:1 usingComparator:comparator];
+
+  for (int section = 0; section < model.sectionCount; ++section) {
+    NSArray *items = [model itemsInSection:section];
+    TKMAssignment *lastAssignment = nil;
+    for (int index = 0; index < items.count; ++index) {
+      TKMAssignment *assignment = ((TKMSubjectModelItem *)items[index]).assignment;
+      if (lastAssignment == nil || lastAssignment.srsStage != assignment.srsStage ||
+          lastAssignment.isReviewStage != assignment.isReviewStage ||
+          lastAssignment.isLessonStage != assignment.isLessonStage) {
+        NSString *label;
+        if (assignment.isReviewStage || assignment.isBurned) {
+          label = TKMDetailedSRSStageName(assignment.srsStage);
+        } else if (assignment.isLessonStage) {
+          label = @"Available in Lessons";
+        } else {
+          label = @"Locked";
+        }
+        [model insertItem:[[TKMListSeparatorItem alloc] initWithLabel:label]
+                  atIndex:index
+                inSection:section];
+        index++;
+      }
+      lastAssignment = assignment;
+    }
+  }
+
+  _model = model;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+  [super viewWillAppear:animated];
+  self.navigationController.navigationBarHidden = NO;
+}
+
+#pragma mark - TKMSubjectDelegate
+
+- (void)didTapSubject:(TKMSubject *)subject {
+  SubjectDetailsViewController *vc =
+  [self.storyboard instantiateViewControllerWithIdentifier:@"subjectDetailsViewController"];
+  [vc setupWithServices:_services subject:subject];
+  [self.navigationController pushViewController:vc animated:YES];
+}
+
+@end

--- a/ios/Tables/TKMSubjectModelItem.h
+++ b/ios/Tables/TKMSubjectModelItem.h
@@ -50,6 +50,7 @@ NS_ASSUME_NONNULL_BEGIN;
 @property(nonatomic) bool meaningWrong;
 @property(nonatomic) bool showLevelNumber;
 @property(nonatomic) bool showAnswers;
+@property(nonatomic) bool showRemaining;
 @property(nonatomic) NSArray<id> *gradientColors;
 
 @end

--- a/ios/Tables/TKMSubjectModelItem.m
+++ b/ios/Tables/TKMSubjectModelItem.m
@@ -103,16 +103,17 @@ static const CGFloat kFontSize = 14.f;
 
  switch (itemLevel) {
     case 1:
-      guruInterval += (isAccelerated ? 7200 : 14400);
+      guruInterval += (isAccelerated ? 2 : 4);
     case 2:
-      guruInterval += (isAccelerated ? 14400 : 28800);
+      guruInterval += (isAccelerated ? 4 : 8);
     case 3:
-      guruInterval += (isAccelerated ? 28800 : 82800);
+      guruInterval += (isAccelerated ? 8 : 23);
     case 4:
-      guruInterval += (isAccelerated ? 82800 : 169200);
+      guruInterval += (isAccelerated ? 23 : 47);
   }
 
-  return [reviewDate dateByAddingTimeInterval:guruInterval];
+  int guruSeconds = guruInterval * 60 * 60;
+  return [reviewDate dateByAddingTimeInterval:guruSeconds];
 }
 
 @end

--- a/ios/Tables/TKMSubjectModelItem.m
+++ b/ios/Tables/TKMSubjectModelItem.m
@@ -66,15 +66,11 @@ static const CGFloat kFontSize = 14.f;
   return @"TKMSubjectModelItem";
 }
 
-- (NSDate *)startOfHour:(NSDate *)date {
-  NSCalendar* calendar = [NSCalendar currentCalendar];
-  NSDateComponents* components = [calendar components:(NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitHour) fromDate:[NSDate date]];
-  return [calendar dateFromComponents: components];
-}
-
 - (NSDate *)reviewDate {
   // If it's available now, treat it like it will be reviewed this hour.
-  NSDate* reviewDate = [self startOfHour: [NSDate date]];
+  NSCalendar* calendar = [NSCalendar currentCalendar];
+  NSDateComponents* components = [calendar components:(NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitHour) fromDate:[NSDate date]];
+  NSDate* reviewDate = [calendar dateFromComponents: components];
 
   // If it's not available now, treat it like it will be reviewed within the hour it comes available.
   if ([reviewDate compare: _assignment.availableAtDate] == NSOrderedAscending) {

--- a/ios/Tables/TKMSubjectModelItem.m
+++ b/ios/Tables/TKMSubjectModelItem.m
@@ -101,28 +101,15 @@ static const CGFloat kFontSize = 14.f;
   double guruInterval = 0;
   bool isAccelerated = _subject.level <= 2;
 
-  if (isAccelerated) {
-    switch (itemLevel) {
-      case 1:
-        guruInterval += 7200;
-      case 2:
-        guruInterval += 14400;
-      case 3:
-        guruInterval += 28800;
-      case 4:
-        guruInterval += 82800;
-    }
-  } else {
-    switch (itemLevel) {
-      case 1:
-        guruInterval += 14400;
-      case 2:
-        guruInterval += 28800;
-      case 3:
-        guruInterval += 82800;
-      case 4:
-        guruInterval += 169200;
-    }
+ switch (itemLevel) {
+    case 1:
+      guruInterval += (isAccelerated ? 7200 : 14400);
+    case 2:
+      guruInterval += (isAccelerated ? 14400 : 28800);
+    case 3:
+      guruInterval += (isAccelerated ? 28800 : 82800);
+    case 4:
+      guruInterval += (isAccelerated ? 82800 : 169200);
   }
 
   return [reviewDate dateByAddingTimeInterval:guruInterval];

--- a/ios/Tables/TKMSubjectModelItem.m
+++ b/ios/Tables/TKMSubjectModelItem.m
@@ -167,6 +167,9 @@ static const CGFloat kFontSize = 14.f;
       [self.readingLabel setHidden:YES];
       [self.meaningLabel setHidden:YES];
     }
+
+    self.readingLabel.font = [UIFont systemFontOfSize:kFontSize];
+    self.meaningLabel.font = [UIFont systemFontOfSize:kFontSize];
   } else {
     if (item.subject.hasRadical) {
       [self.readingLabel setHidden:YES];

--- a/ios/Tables/TKMSubjectModelItem.m
+++ b/ios/Tables/TKMSubjectModelItem.m
@@ -43,6 +43,7 @@ static const CGFloat kFontSize = 14.f;
     _readingWrong = readingWrong;
     _showLevelNumber = true;
     _showAnswers = true;
+    _showRemaining = false;
   }
   return self;
 }
@@ -63,6 +64,72 @@ static const CGFloat kFontSize = 14.f;
 
 - (NSString *)cellNibName {
   return @"TKMSubjectModelItem";
+}
+
+- (NSDate *)startOfHour:(NSDate *)date {
+  NSCalendar* calendar = [NSCalendar currentCalendar];
+  NSDateComponents* components = [calendar components:(NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitHour) fromDate:[NSDate date]];
+  return [calendar dateFromComponents: components];
+}
+
+- (NSDate *)reviewDate {
+  // If it's available now, treat it like it will be reviewed this hour.
+  NSDate* reviewDate = [self startOfHour: [NSDate date]];
+
+  // If it's not available now, treat it like it will be reviewed within the hour it comes available.
+  if ([reviewDate compare: _assignment.availableAtDate] == NSOrderedAscending) {
+    reviewDate = _assignment.availableAtDate;
+  }
+
+  return reviewDate;
+}
+
+- (NSDate *)guruDate {
+  if (_assignment.hasPassedAt) {
+    return _assignment.passedAtDate;
+  }
+
+  int itemLevel = _assignment.srsStage + 1;
+  int guruLevel = 5;
+
+  if (itemLevel > guruLevel) {
+    return [NSDate distantPast];
+  }
+
+  NSDate* reviewDate = [self reviewDate];
+
+  if (itemLevel == guruLevel) {
+    return reviewDate;
+  }
+
+  double guruInterval = 0;
+  bool isAccelerated = _subject.level <= 2;
+
+  if (isAccelerated) {
+    switch (itemLevel) {
+      case 1:
+        guruInterval += 7200;
+      case 2:
+        guruInterval += 14400;
+      case 3:
+        guruInterval += 28800;
+      case 4:
+        guruInterval += 82800;
+    }
+  } else {
+    switch (itemLevel) {
+      case 1:
+        guruInterval += 14400;
+      case 2:
+        guruInterval += 28800;
+      case 3:
+        guruInterval += 82800;
+      case 4:
+        guruInterval += 169200;
+    }
+  }
+
+  return [reviewDate dateByAddingTimeInterval:guruInterval];
 }
 
 @end
@@ -99,25 +166,68 @@ static const CGFloat kFontSize = 14.f;
 
   self.subjectLabel.font = TKMJapaneseFont(self.subjectLabel.font.pointSize);
   self.subjectLabel.attributedText =
-      [item.subject japaneseTextWithImageSize:kJapaneseTextImageSize];
-  if (item.subject.hasRadical) {
-    [self.readingLabel setHidden:YES];
-    self.meaningLabel.text = item.subject.commaSeparatedMeanings;
-  } else if (item.subject.hasKanji) {
-    [self.readingLabel setHidden:NO];
-    self.readingLabel.text = item.subject.commaSeparatedPrimaryReadings;
-    self.meaningLabel.text = item.subject.commaSeparatedMeanings;
-  } else if (item.subject.hasVocabulary) {
-    [self.readingLabel setHidden:NO];
-    self.readingLabel.text = item.subject.commaSeparatedReadings;
-    self.meaningLabel.text = item.subject.commaSeparatedMeanings;
+  [item.subject japaneseTextWithImageSize:kJapaneseTextImageSize];
+
+  if (item.showRemaining) {
+    if (item.assignment.isReviewStage) {
+      [self.readingLabel setHidden:NO];
+      self.readingLabel.text = [self formattedIntervalUntil: [item reviewDate] label: @"Review"];
+      [self.meaningLabel setHidden:NO];
+      self.meaningLabel.text = [self formattedIntervalUntil: [item guruDate] label: @"Guru"];
+    } else if (item.assignment.isLessonStage) {
+      [self.readingLabel setHidden:NO];
+      self.readingLabel.text = [self formattedIntervalUntil: [item guruDate] label: @"Guru"];
+      [self.meaningLabel setHidden:YES];
+    } else {
+      [self.readingLabel setHidden:YES];
+      [self.meaningLabel setHidden:YES];
+    }
+  } else {
+    if (item.subject.hasRadical) {
+      [self.readingLabel setHidden:YES];
+      self.meaningLabel.text = item.subject.commaSeparatedMeanings;
+    } else if (item.subject.hasKanji) {
+      [self.readingLabel setHidden:NO];
+      self.readingLabel.text = item.subject.commaSeparatedPrimaryReadings;
+      self.meaningLabel.text = item.subject.commaSeparatedMeanings;
+    } else if (item.subject.hasVocabulary) {
+      [self.readingLabel setHidden:NO];
+      self.readingLabel.text = item.subject.commaSeparatedReadings;
+      self.meaningLabel.text = item.subject.commaSeparatedMeanings;
+    }
+
+    self.readingLabel.font = item.readingWrong ? TKMJapaneseFontBold(kFontSize) : TKMJapaneseFont(kFontSize);
+    self.meaningLabel.font = item.meaningWrong ? [UIFont systemFontOfSize:kFontSize weight:UIFontWeightBold]
+      : [UIFont systemFontOfSize:kFontSize];
   }
 
-  self.readingLabel.font = item.readingWrong ? TKMJapaneseFontBold(kFontSize) : TKMJapaneseFont(kFontSize);
-  self.meaningLabel.font = item.meaningWrong ? [UIFont systemFontOfSize:kFontSize weight:UIFontWeightBold]
-    : [UIFont systemFontOfSize:kFontSize];
+  bool showDetail = item.showAnswers || item.showRemaining;
+  [self setShowAnswers:showDetail animated:false];
+}
 
-  [self setShowAnswers:item.showAnswers animated:false];
+- (NSString *)formattedIntervalUntil:(NSDate *)toDate
+                               label:(NSString*)label {
+  if ([[NSDate date] compare:toDate] == NSOrderedDescending) {
+    return [NSString stringWithFormat:@"%@ available", label];
+  }
+
+  NSDateComponentsFormatter *formatter = [[NSDateComponentsFormatter alloc] init];
+  formatter.unitsStyle = NSDateComponentsFormatterUnitsStyleAbbreviated;
+
+  int componentsBitMask = NSCalendarUnitDay|NSCalendarUnitHour|NSCalendarUnitMinute;
+  NSDateComponents *components = [[NSCalendar currentCalendar]
+                                  components:componentsBitMask
+                                  fromDate:[NSDate date]
+                                  toDate:toDate
+                                  options:0];
+
+  // Only show minutes after there are no hours left
+  if (components.hour > 0) {
+    [components setMinute: 0];
+  }
+
+  NSString* interval = [formatter stringFromDateComponents:components];
+  return [NSString stringWithFormat:@"%@ in %@", label, interval];
 }
 
 - (void)setShowAnswers:(bool)showAnswers animated:(bool)animated {

--- a/ios/Tables/TKMSubjectModelItem.m
+++ b/ios/Tables/TKMSubjectModelItem.m
@@ -101,7 +101,8 @@ static const CGFloat kFontSize = 14.f;
   double guruInterval = 0;
   bool isAccelerated = _subject.level <= 2;
 
- switch (itemLevel) {
+  // From https://docs.api.wanikani.com/20170710/#additional-information
+  switch (itemLevel) {
     case 1:
       guruInterval += (isAccelerated ? 2 : 4);
     case 2:

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		63EEFECD1FC45D810070C05F /* ReviewViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 63EEFEC71FC45D800070C05F /* ReviewViewController.mm */; };
 		63EEFED31FC45E810070C05F /* MainViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 63EEFED21FC45E810070C05F /* MainViewController.m */; };
 		63EEFED91FC46E720070C05F /* Client.m in Sources */ = {isa = PBXBuildFile; fileRef = 63EEFED81FC46E720070C05F /* Client.m */; };
+		657E731E22DAD99C00F6F4C1 /* SubjectsRemainingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 657E731D22DAD99C00F6F4C1 /* SubjectsRemainingViewController.m */; };
 		BB0F6B0C216698F800CB1306 /* TKMKanaInputTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BB0F6B0B216698F800CB1306 /* TKMKanaInputTest.m */; };
 		BBE4E32E2172576B003A200E /* TKMFontLoader.mm in Sources */ = {isa = PBXBuildFile; fileRef = BBE4E32D2172576B003A200E /* TKMFontLoader.mm */; };
 		BBE4E332217276EC003A200E /* TKMFontsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BBE4E331217276EC003A200E /* TKMFontsViewController.m */; };
@@ -668,6 +669,8 @@
 		63EEFED21FC45E810070C05F /* MainViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainViewController.m; sourceTree = "<group>"; };
 		63EEFED71FC46E720070C05F /* Client.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Client.h; sourceTree = "<group>"; };
 		63EEFED81FC46E720070C05F /* Client.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Client.m; sourceTree = "<group>"; };
+		657E731C22DAD99C00F6F4C1 /* SubjectsRemainingViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SubjectsRemainingViewController.h; sourceTree = "<group>"; };
+		657E731D22DAD99C00F6F4C1 /* SubjectsRemainingViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SubjectsRemainingViewController.m; sourceTree = "<group>"; };
 		BB0F6B0B216698F800CB1306 /* TKMKanaInputTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TKMKanaInputTest.m; sourceTree = "<group>"; };
 		BB0F6B10216B333700CB1306 /* TKMKanaInput+Internals.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TKMKanaInput+Internals.h"; sourceTree = "<group>"; };
 		BB2909A5217FAF8B00B1816F /* fonts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fonts; sourceTree = "<group>"; };
@@ -1067,6 +1070,8 @@
 				63B1DE401FE7D81600FAB9C2 /* SubjectDetailsViewController.m */,
 				63E9A8CA210D6CC000418CE1 /* SubjectsByLevelViewController.h */,
 				63E9A8CB210D6CC000418CE1 /* SubjectsByLevelViewController.m */,
+				657E731C22DAD99C00F6F4C1 /* SubjectsRemainingViewController.h */,
+				657E731D22DAD99C00F6F4C1 /* SubjectsRemainingViewController.m */,
 				63BDA9A8200E12F900D75DA2 /* SuccessAnimation.h */,
 				63BDA9A9200E12F900D75DA2 /* SuccessAnimation.m */,
 				633DE93C20C2CA0600AC25F4 /* Tables */,
@@ -1632,6 +1637,7 @@
 				630ADDAD21FEB34C00BC9801 /* BarLineScatterCandleBubbleChartDataProvider.swift in Sources */,
 				63CAAACD1FC6E0BA00E09DA1 /* Any.pbobjc.m in Sources */,
 				633DE95820C5634A00AC25F4 /* TKMModelItem.m in Sources */,
+				657E731E22DAD99C00F6F4C1 /* SubjectsRemainingViewController.m in Sources */,
 				630ADD8821FEB34B00BC9801 /* LineChartData.swift in Sources */,
 				63B1DE3B1FE7BCDA00FAB9C2 /* ReviewSummaryViewController.m in Sources */,
 				633DE96120C5656B00AC25F4 /* TKMMarkupModelItem.m in Sources */,


### PR DESCRIPTION
This is the screen I've always wanted in Tsurukame, and I think means that I won't need to keep AlliCrab installed anymore (😅). The "Show remaining" screen shows the radicals and kanji that have not yet reached guru status on the current level, along with the next times each item will be reviewable and could potentially reach guru. Here's what it looks like:

![Simulator Screen Shot - iPhone X - 2019-07-14 at 14 48 03](https://user-images.githubusercontent.com/78/61189741-80c7a580-a646-11e9-9779-e78abad8be83.png)

![Simulator Screen Shot - iPhone X - 2019-07-14 at 01 27 50](https://user-images.githubusercontent.com/78/61181232-5808c700-a5d8-11e9-8678-a8820725cabe.png)

![Simulator Screen Shot - iPhone X - 2019-07-14 at 01 28 04](https://user-images.githubusercontent.com/78/61181233-5a6b2100-a5d8-11e9-939d-239a7a3328a6.png)
