### PR TITLE
start lessons with ⌘L and reviews with ⌘R

### DIFF
--- a/ios/MainViewController.m
+++ b/ios/MainViewController.m
@@ -481,4 +481,32 @@ static void SetTableViewCellCount(UITableViewCell *cell, int count) {
                                         }];
 }
 
+#pragma mark - Keyboard navigation
+
+- (BOOL)canBecomeFirstResponder {
+  return true;
+}
+
+- (void)startReviews {
+  [self performSegueWithIdentifier:@"startReviews" sender:self];
+}
+
+- (void)startLessons {
+  [self performSegueWithIdentifier:@"startLessons" sender:self];
+}
+
+- (NSArray<UIKeyCommand *> *)keyCommands {
+  return @[
+           [UIKeyCommand keyCommandWithInput:@"r"
+                               modifierFlags:UIKeyModifierCommand
+                                      action:@selector(startReviews)
+                        discoverabilityTitle:@"Start reviews"],
+           [UIKeyCommand keyCommandWithInput:@"l"
+                               modifierFlags:UIKeyModifierCommand
+                                      action:@selector(startLessons)
+                        discoverabilityTitle:@"Start lessons"]
+           ];
+}
+
+
 @end


### PR DESCRIPTION
This commit adds keyboard shortcuts to the main screen, allowing you to start reviews and lessons from the keyboard. It's especially handy to be able to do this when you have more than 5 lessons, and you want to keep going with another five after finishing a batch (which you can do entirely on the keyboard, now!)