### PR TITLE
stop allowing ListSeparatorCell to be selected

### DIFF
--- a/ios/Tables/TKMListSeparatorItem.h
+++ b/ios/Tables/TKMListSeparatorItem.h
@@ -22,3 +22,7 @@
 @property(nonatomic, readonly) NSString *label;
 
 @end
+
+@interface TKMListSeparatorCell : TKMModelCell
+@property(nonatomic, weak) IBOutlet UILabel *label;
+@end

--- a/ios/Tables/TKMListSeparatorItem.m
+++ b/ios/Tables/TKMListSeparatorItem.m
@@ -15,10 +15,6 @@
 #import "TKMListSeparatorItem.h"
 #import "Style.h"
 
-@interface TKMListSeparatorCell : TKMModelCell
-@property(nonatomic, weak) IBOutlet UILabel *label;
-@end
-
 @implementation TKMListSeparatorItem
 
 - (instancetype)initWithLabel:(NSString *)label {

--- a/ios/Tables/TKMListSeparatorItem.xib
+++ b/ios/Tables/TKMListSeparatorItem.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,7 +19,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0hv-D6-PYI">
-                        <rect key="frame" x="168" y="-4" width="37.5" height="17"/>
+                        <rect key="frame" x="169" y="-4" width="37.5" height="17.5"/>
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
@@ -30,6 +31,9 @@
                     <constraint firstItem="0hv-D6-PYI" firstAttribute="centerY" secondItem="QGA-Uh-22D" secondAttribute="centerY" id="Tbe-G6-P4y"/>
                 </constraints>
             </tableViewCellContentView>
+            <accessibility key="accessibilityConfiguration">
+                <accessibilityTraits key="traits" notEnabled="YES"/>
+            </accessibility>
             <connections>
                 <outlet property="label" destination="0hv-D6-PYI" id="JmS-6L-pqe"/>
             </connections>

--- a/ios/Tables/TKMTableModel.m
+++ b/ios/Tables/TKMTableModel.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "TKMTableModel.h"
+#import "TKMListSeparatorItem.h"
 
 @interface TKMTableModelSection : NSObject
 
@@ -179,6 +180,11 @@
 }
 
 #pragma mark - UITableViewDelegate
+
+- (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+  TKMModelCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+  return (cell.class == TKMListSeparatorCell.class) ? nil : indexPath;
+}
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
   TKMModelCell *cell = [tableView cellForRowAtIndexPath:indexPath];


### PR DESCRIPTION
I noticed that you could tap on the separators, and they would stay selected and highlighted forever. This stops that by keeping them from being selectable.