### PR TITLE
Review items can reach srsStage zero if missed

### DIFF
--- a/ios/proto/Wanikani+Convenience.m
+++ b/ios/proto/Wanikani+Convenience.m
@@ -316,7 +316,7 @@ NSString *TKMDetailedSRSStageName(int srsStage) {
 }
 
 - (bool)isReviewStage {
-  return self.hasId_p && self.hasAvailableAt && self.srsStage != 0;
+  return self.hasId_p && self.hasAvailableAt;
 }
 
 - (bool)isBurned {


### PR DESCRIPTION
Here's where we allow srsStage to go all the way back to zero if the
item is missed enough times:

https://github.com/davidsansome/tsurukame/blob/ebafb39423fed00ba2414ddacfbe83c5e095393d/ios/LocalCachingClient.mm#L671

We shouldn't treat them as locked just because their srsStage has
dropped back to zero.

fixes #148