### PR TITLE
Give Available Lessons a remaining time that makes sense

### DIFF
--- a/ios/Tables/TKMSubjectModelItem.m
+++ b/ios/Tables/TKMSubjectModelItem.m
@@ -67,6 +67,11 @@ static const CGFloat kFontSize = 14.f;
 }
 
 - (NSDate *)reviewDate {
+  // If it's available in a lesson, assume it will be quizzed this hour.
+  if (!_assignment.hasAvailableAt) {
+    return [NSDate date];
+  }
+
   // If it's available now, treat it like it will be reviewed this hour.
   NSCalendar* calendar = [NSCalendar currentCalendar];
   NSDateComponents* components = [calendar components:(NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitHour) fromDate:[NSDate date]];


### PR DESCRIPTION
After using the app, the "remaining time" that makes the most sense to me for items that are "available in lessons" is the amount of time it would take if you were to do the lesson immediately and then get every following review correct. This commit implements that.