### PR TITLE
Add keyboard shortcut toggling font randomization

### DIFF
--- a/ios/ReviewViewController.mm
+++ b/ios/ReviewViewController.mm
@@ -1081,7 +1081,12 @@ class AnimationContext {
 
 - (NSArray<UIKeyCommand *> *)keyCommands {
   if (_subjectDetailsView.hidden) {
-    return @[];
+    return @[
+      [UIKeyCommand keyCommandWithInput:@"\t"
+                          modifierFlags:0
+                                 action:@selector(toggleFont)
+                   discoverabilityTitle:@"Toggle font"]
+      ];
   }
 
   return @[
@@ -1112,6 +1117,11 @@ class AnimationContext {
   if (!_subjectDetailsView.hidden) {
     [_subjectDetailsView playAudio];
   }
+}
+
+- (void)toggleFont {
+  BOOL useCustomFont = [_questionLabel.font isEqual:TKMJapaneseFontLight(_questionLabel.font.pointSize)];
+  [self setCustomQuestionLabelFont:useCustomFont];
 }
 
 @end

--- a/ios/Style.m
+++ b/ios/Style.m
@@ -103,9 +103,13 @@ UIFont *TKMJapaneseFont(CGFloat size) {
 }
 
 UIFont *TKMJapaneseFontLight(CGFloat size) {
-  return [UIFont fontWithName:[NSString stringWithFormat:@"%@ W3", kTKMJapaneseFontName] size:size];
+  return [UIFont fontWithName:[NSString stringWithFormat:@"%@-W3",
+                               [kTKMJapaneseFontName stringByReplacingOccurrencesOfString:@" " withString:@""]]
+                                                    size:size];
 }
 
 UIFont *TKMJapaneseFontBold(CGFloat size) {
-  return [UIFont fontWithName:[NSString stringWithFormat:@"%@ W8", kTKMJapaneseFontName] size:size];
+  return [UIFont fontWithName:[NSString stringWithFormat:@"%@-W8",
+                               [kTKMJapaneseFontName stringByReplacingOccurrencesOfString:@" " withString:@""]]
+                                                   size:size];
 }


### PR DESCRIPTION
This makes it so the `tab` key toggles the displayed font (like long
pressing does) during reviews. This addresses #117.

There's a little bit of weirdness around font names in iOS it seems, so there may be a simpler way of doing this.