### PR TITLE
Make keyboard cheats use the command key

### DIFF
--- a/ios/ReviewViewController.mm
+++ b/ios/ReviewViewController.mm
@@ -1068,6 +1068,13 @@ class AnimationContext {
   [self markAnswer:TKMOverrideAnswerCorrect];
 }
 
+// For no particularly apparent reason, this seemingly pointless implementation
+// means that holding down the command key after (say) pressing ⌘C does not
+// repeat the action continuously on all subsequent reviews
+-(BOOL) canPerformAction:(SEL)action withSender:(id)sender {
+  return [super canPerformAction:action withSender:sender];
+}
+
 #pragma mark - TKMSubjectDelegate
 
 - (void)didTapSubject:(TKMSubject *)subject {

--- a/ios/ReviewViewController.mm
+++ b/ios/ReviewViewController.mm
@@ -1098,15 +1098,15 @@ class AnimationContext {
                                action:@selector(playAudio)
                  discoverabilityTitle:@"Play reading"],
     [UIKeyCommand keyCommandWithInput:@"a"
-                        modifierFlags:0
+                        modifierFlags:UIKeyModifierCommand
                                action:@selector(askAgain)
                  discoverabilityTitle:@"Ask again later"],
     [UIKeyCommand keyCommandWithInput:@"c"
-                        modifierFlags:0
+                        modifierFlags:UIKeyModifierCommand
                                action:@selector(markCorrect)
                  discoverabilityTitle:@"Mark correct"],
     [UIKeyCommand keyCommandWithInput:@"s"
-                        modifierFlags:0
+                        modifierFlags:UIKeyModifierCommand
                                action:@selector(addSynonym)
                  discoverabilityTitle:@"Add as synonym"]
   ];


### PR DESCRIPTION
It's easy to accidentally type a single letter by itself after missing a review, and the cheat actions have no undo. By making these shortcuts command key shortcuts, it's much harder to accidentally trigger them.

Fixes #166, I think.