### PR TITLE
Study shortcut improvements

### DIFF
--- a/ios/MainViewController.m
+++ b/ios/MainViewController.m
@@ -529,16 +529,31 @@ static void SetTableViewCellCount(UITableViewCell *cell, int count) {
 }
 
 - (NSArray<UIKeyCommand *> *)keyCommands {
-  return @[
-    [UIKeyCommand keyCommandWithInput:@"r"
-                        modifierFlags:UIKeyModifierCommand
-                               action:@selector(startReviews)
-                 discoverabilityTitle:@"Start reviews"],
-    [UIKeyCommand keyCommandWithInput:@"l"
-                        modifierFlags:UIKeyModifierCommand
-                               action:@selector(startLessons)
-                 discoverabilityTitle:@"Start lessons"]
-  ];
+  BOOL lessons = self.lessonsCell.userInteractionEnabled;
+  BOOL reviews = self.reviewsCell.userInteractionEnabled;
+
+  NSMutableArray<UIKeyCommand *> *keyCommands = [NSMutableArray array];
+
+  // Command L to start lessons, if any
+  if (lessons) {
+    [keyCommands addObject:
+     [UIKeyCommand keyCommandWithInput:@"l"
+                         modifierFlags:UIKeyModifierCommand
+                                action:@selector(startLessons)
+                  discoverabilityTitle:@"Start lessons"]
+     ];
+  }
+
+  // Command R to start reviews, if any
+  if (reviews) {
+    [keyCommands addObject:
+     [UIKeyCommand keyCommandWithInput:@"r"
+                         modifierFlags:UIKeyModifierCommand
+                                action:@selector(startReviews)
+                  discoverabilityTitle:@"Start reviews"]];
+  }
+
+  return keyCommands;
 }
 
 @end

--- a/ios/MainViewController.m
+++ b/ios/MainViewController.m
@@ -534,6 +534,23 @@ static void SetTableViewCellCount(UITableViewCell *cell, int count) {
 
   NSMutableArray<UIKeyCommand *> *keyCommands = [NSMutableArray array];
 
+  // Press return to keep studying, first lessons then reviews
+  if (lessons && !reviews) {
+    [keyCommands addObject:
+     [UIKeyCommand keyCommandWithInput:@"\r"
+                         modifierFlags:0
+                                action:@selector(startLessons)
+                  discoverabilityTitle:@"Continue lessons"]
+     ];
+  } else if (reviews) {
+    [keyCommands addObject:
+     [UIKeyCommand keyCommandWithInput:@"\r"
+                         modifierFlags:0
+                                action:@selector(startReviews)
+                  discoverabilityTitle:@"Continue reviews"]
+     ];
+  }
+
   // Command L to start lessons, if any
   if (lessons) {
     [keyCommands addObject:


### PR DESCRIPTION
The main screen keyboard shortcuts for lessons and reviews would wrongly try to trigger even if there were no lessons or reviews, and could get the app into a stuck state.

This also adds a convenience shortcut of "push return to keep studying", which will work as long as there are reviews or lessons remaining.