### PR TITLE
Allow reviews without clicking on macOS

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -640,6 +640,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
       if ctx.cheats {
         addSynonymButton.isHidden = true
       }
+      answerField.becomeFirstResponder()
     }
   }
 


### PR DESCRIPTION
This is the only patch that seemed really needed to make reviews on macOS work. Without this patch, you have to click the mouse to focus on the text entry box after each animation. With this patch, you can type answers one after another, like on an iPhone or iPad.