### PR TITLE
Fixed typo (#206)

### DIFF
--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -152,7 +152,7 @@ class SubjectDetailsView: UITableView, TKMSubjectChipDelegate {
         continue
       }
       if !addedSection {
-        model.addSection("Visually Similar Kanhi")
+        model.addSection("Visually Similar Kanji")
         addedSection = true
       }
 


### PR DESCRIPTION
Fixes #206 - should be "Kanji" not "Kanhi".