### PR TITLE
Dark mode fixes

### DIFF
--- a/ios/CurrentLevelChartItem.swift
+++ b/ios/CurrentLevelChartItem.swift
@@ -202,8 +202,8 @@ class CurrentLevelChartCell: TKMModelCell {
 
     let dataSet = PieChartDataSet(values)
     if #available(iOS 13.0, *) {
-      dataSet.valueTextColor = UIColor.secondaryLabel
-      dataSet.entryLabelColor = UIColor.label
+      dataSet.valueTextColor = UIColor.label
+      dataSet.entryLabelColor = UIColor.secondaryLabel
     } else {
       dataSet.valueTextColor = UIColor.darkGray
       dataSet.entryLabelColor = UIColor.black

--- a/ios/LessonsViewController.m
+++ b/ios/LessonsViewController.m
@@ -47,6 +47,10 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
+  if (@available(iOS 13.0, *)) {
+    _pageControl.backgroundColor = UIColor.systemBackgroundColor;
+  }
+
   // Create the page controller.
   _pageController = [[UIPageViewController alloc]
       initWithTransitionStyle:UIPageViewControllerTransitionStyleScroll

--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -36,7 +36,11 @@ class LevelTimeRemainingCell: TKMModelCell {
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     selectionStyle = .none
-    detailTextLabel?.textColor = UIColor.black
+    if #available(iOS 13.0, *) {
+      detailTextLabel?.textColor = UIColor.label
+    } else {
+      detailTextLabel?.textColor = UIColor.black
+    }
   }
 
   required init?(coder _: NSCoder) {

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -526,6 +526,10 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
     levelLabel.accessibilityLabel = "srs level \(activeTask.assignment.srsStage)"
 
     answerField.text = nil
+    if #available(iOS 13.0, *) {
+      answerField.textColor = UIColor.label
+      answerField.backgroundColor = UIColor.systemBackground
+    }
     answerField.placeholder = taskTypePlaceholder
     if let firstReading = activeSubject.primaryReadings.first {
       kanaInput.alphabet = (
@@ -665,11 +669,11 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
     previousSubjectButton.alpha = shown ? 0.0 : 1.0
 
     // Change the background color of the answer field.
+    var textColor = UIColor.white
     if #available(iOS 13.0, *) {
-      answerField.textColor = shown ? UIColor.systemRed : UIColor.label
-    } else {
-      answerField.textColor = shown ? UIColor.systemRed : UIColor.white
+      textColor = UIColor.label
     }
+    answerField.textColor = shown ? UIColor.systemRed : textColor
 
     // Scroll to the top.
     subjectDetailsView.setContentOffset(CGPoint(x: 0, y: -subjectDetailsView.contentInset.top), animated: false)

--- a/ios/SRSStageCategoryItem.swift
+++ b/ios/SRSStageCategoryItem.swift
@@ -26,7 +26,12 @@ import Foundation
                target: nil,
                action: nil)
 
-    let color = TKMStyle.color(forSRSStageCategory: stageCategory)
+    var color = TKMStyle.color(forSRSStageCategory: stageCategory)
+
+    if #available(iOS 13.0, *), stageCategory == .burned,
+      UITraitCollection.current.userInterfaceStyle == .dark {
+      color = UIColor.label
+    }
     textColor = color
     imageTintColor = color
     image = UIImage(named: TKMSRSStageCategoryName(stageCategory))!

--- a/ios/Style.swift
+++ b/ios/Style.swift
@@ -43,6 +43,10 @@ class TKMStyle: NSObject {
   static let lockedColor2 = UIColorFromHex(0x484848)
   static let greyColor = UIColorFromHex(0xC8C8C8)
 
+  static let radicalBackgroundColor = UIColor(red: 0.839, green: 0.945, blue: 1, alpha: 1)
+  static let kanjiBackgroundColor = UIColor(red: 1, green: 0.839, blue: 0.945, alpha: 1)
+  static let vocabularyBackgroundColor = UIColor(red: 0.945, green: 0.839, blue: 1, alpha: 1)
+
   // The [Any] types force these to be exposed to objective-C as an untyped NSArray*.
   static let radicalGradient: [Any] = [radicalColor1.cgColor, radicalColor2.cgColor]
   static let kanjiGradient: [Any] = [kanjiColor1.cgColor, kanjiColor2.cgColor]

--- a/ios/Style.swift
+++ b/ios/Style.swift
@@ -62,7 +62,11 @@ class TKMStyle: NSObject {
     case .burned:
       return UIColor(red: 0.26, green: 0.26, blue: 0.26, alpha: 1.0)
     default:
-      return UIColor.black
+      if #available(iOS 13.0, *) {
+        return UIColor.label
+      } else {
+        return UIColor.black
+      }
     }
   }
 

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -82,10 +82,17 @@ private func attrString(_ string: String, attrs: [NSAttributedString.Key: Any]? 
 
 private func defaultStringAttrs() -> [NSAttributedString.Key: Any] {
   if #available(iOS 13.0, *) {
-    return [
-      .foregroundColor: UIColor.label,
-      .backgroundColor: UIColor.secondarySystemBackground,
-    ]
+    #if targetEnvironment(macCatalyst)
+      return [
+        .foregroundColor: UIColor.label,
+        .backgroundColor: UIColor.secondarySystemBackground,
+      ]
+    #else
+      return [
+        .foregroundColor: UIColor.label,
+        .backgroundColor: UIColor.systemBackground,
+      ]
+    #endif
   } else {
     return [
       .foregroundColor: UIColor.black,

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -89,17 +89,7 @@ private func attrString(_ string: String, attrs: [NSAttributedString.Key: Any]? 
 
 private func defaultStringAttrs() -> [NSAttributedString.Key: Any] {
   if #available(iOS 13.0, *) {
-    #if targetEnvironment(macCatalyst)
-      return [
-        .foregroundColor: UIColor.label,
-        .backgroundColor: UIColor.secondarySystemBackground,
-      ]
-    #else
-      return [
-        .foregroundColor: UIColor.label,
-        .backgroundColor: UIColor.systemBackground,
-      ]
-    #endif
+    return [.foregroundColor: UIColor.label]
   } else {
     return [
       .foregroundColor: UIColor.black,

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -21,8 +21,15 @@ private let kFontSize: CGFloat = 14.0
 private let kVisuallySimilarKanjiScoreThreshold = 400
 
 private let kMeaningSynonymColor = UIColor(red: 0.231, green: 0.6, blue: 0.988, alpha: 1)
-private let kHintTextColor = UIColor(white: 0.3, alpha: 1.0)
 private let kFont = TKMStyle.japaneseFont(size: kFontSize)
+
+private func kHintTextColor() -> UIColor {
+  if #available(iOS 13.0, *) {
+    return UIColor.secondaryLabel
+  } else {
+    return UIColor(white: 0.3, alpha: 1.0)
+  }
+}
 
 private func join(_ arr: [NSAttributedString], with joinString: String) -> NSAttributedString {
   let ret = NSMutableAttributedString()
@@ -211,7 +218,7 @@ class SubjectDetailsView: UITableView, TKMSubjectChipDelegate {
 
     var attributes = defaultStringAttrs()
     if isHint {
-      attributes[.foregroundColor] = kHintTextColor
+      attributes[.foregroundColor] = kHintTextColor()
     }
 
     let formattedText = TKMRenderFormattedText(text, attributes).replaceFontSize(kFontSize)

--- a/ios/Tables/TKMAttributedModelItem.m
+++ b/ios/Tables/TKMAttributedModelItem.m
@@ -49,6 +49,7 @@ static const CGFloat kMinimumHeight = 44.f;
     _textView.scrollEnabled = NO;
     _textView.textContainerInset = UIEdgeInsetsZero;
     _textView.textContainer.lineFragmentPadding = 0.f;
+    _textView.backgroundColor = UIColor.clearColor;
 
     [self.contentView addSubview:_textView];
   }

--- a/ios/Tables/TKMMarkupModelItem.m
+++ b/ios/Tables/TKMMarkupModelItem.m
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 #import "TKMMarkupModelItem.h"
-
-static UIColor *kRadicalBackgroundColor;
-static UIColor *kKanjiBackgroundColor;
-static UIColor *kVocabularyBackgroundColor;
+#import "Tsurukame-Swift.h"
 
 static NSAttributedString *AttributedStringForFormattedText(
     TKMFormattedText *formattedText, NSDictionary<NSAttributedStringKey, id> *standardAttributes) {
@@ -31,15 +28,15 @@ static NSAttributedString *AttributedStringForFormattedText(
     switch (format) {
       case TKMFormattedText_Format_Kanji:
         [attributes setValue:[UIColor blackColor] forKey:NSForegroundColorAttributeName];
-        [attributes setValue:kKanjiBackgroundColor forKey:NSBackgroundColorAttributeName];
+        [attributes setValue:[TKMStyle kanjiBackgroundColor] forKey:NSBackgroundColorAttributeName];
         break;
       case TKMFormattedText_Format_Radical:
         [attributes setValue:[UIColor blackColor] forKey:NSForegroundColorAttributeName];
-        [attributes setValue:kRadicalBackgroundColor forKey:NSBackgroundColorAttributeName];
+        [attributes setValue:[TKMStyle radicalBackgroundColor] forKey:NSBackgroundColorAttributeName];
         break;
       case TKMFormattedText_Format_Vocabulary:
         [attributes setValue:[UIColor blackColor] forKey:NSForegroundColorAttributeName];
-        [attributes setValue:kVocabularyBackgroundColor forKey:NSBackgroundColorAttributeName];
+        [attributes setValue:[TKMStyle vocabularyBackgroundColor] forKey:NSBackgroundColorAttributeName];
         break;
       case TKMFormattedText_Format_Reading:
         if (@available(iOS 13.0, *)) {
@@ -74,16 +71,6 @@ static NSAttributedString *AttributedStringForFormattedText(
 NSMutableAttributedString *TKMRenderFormattedText(
     NSArray<TKMFormattedText *> *formattedText,
     NSDictionary<NSAttributedStringKey, id> *standardAttributes) {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    kRadicalBackgroundColor = [UIColor colorWithRed:0.839 green:0.945 blue:1 alpha:1];  // #d6f1ff
-    kKanjiBackgroundColor = [UIColor colorWithRed:1 green:0.839 blue:0.945 alpha:1];    // #ffd6f1
-    kVocabularyBackgroundColor = [UIColor colorWithRed:0.945
-                                                 green:0.839
-                                                  blue:1
-                                                 alpha:1];  // #f1d6ff
-  });
-
   NSMutableAttributedString *text = [[NSMutableAttributedString alloc] init];
   for (TKMFormattedText *part in formattedText) {
     [text appendAttributedString:AttributedStringForFormattedText(part, standardAttributes)];

--- a/ios/UpcomingReviewsChartItem.swift
+++ b/ios/UpcomingReviewsChartItem.swift
@@ -129,6 +129,11 @@ class UpcomingReviewsChartCell: TKMModelCell {
     barDataSet.colors = [TKMStyle.radicalColor2]
     barDataSet.valueFormatter = DefaultValueFormatter(decimals: 0)
 
+    if #available(iOS 13.0, *) {
+      lineDataSet.valueTextColor = UIColor.label
+      barDataSet.valueTextColor = UIColor.label
+    }
+
     let data = CombinedChartData()
     data.lineData = LineChartData(dataSet: lineDataSet)
     data.barData = BarChartData(dataSet: barDataSet)

--- a/ios/UpcomingReviewsChartItem.swift
+++ b/ios/UpcomingReviewsChartItem.swift
@@ -79,6 +79,10 @@ class UpcomingReviewsChartCell: TKMModelCell {
     view.legend.enabled = false
     view.chartDescription = nil
     view.isUserInteractionEnabled = false
+    if #available(iOS 13.0, *) {
+      view.xAxis.labelTextColor = UIColor.label
+      view.leftAxis.labelTextColor = UIColor.label
+    }
   }
 
   required init!(coder _: NSCoder) {


### PR DESCRIPTION
This fixes the main (and easy) bits from #216.

In dark mode:
- [x] remaining time (eg 3d 4h) should be light
- [x] "burned" label on dashboard should be light/readable
- [x] review answer field text should be visible as it is typed
- [x] lesson hint text should be dark background, light text
- [x] chart labels text are black but should be white
- [x] multiline strings right hand margin color should not be visible
- [x] hint text on e.g. kanji mnemonics should update to secondary text color
- [x] lessons chip holder should be dark background

In light mode:
- [x] NSAttributedString should not have visible backgrounds
- [x] text in Review mode description, above the answer text field
