### PR TITLE
Renamed Novice to Apprentice I (Fixes #224)

### DIFF
--- a/ios/CurrentLevelChartItem.swift
+++ b/ios/CurrentLevelChartItem.swift
@@ -18,7 +18,6 @@ import Foundation
 enum PieSlice: Int {
   case Locked = 0
   case Lesson
-  case Novice
   case Apprentice
   case Guru
   static let count = 5
@@ -29,8 +28,6 @@ enum PieSlice: Int {
       return "Locked"
     case .Lesson:
       return "Lesson"
-    case .Novice:
-      return TKMSRSStageCategoryName(.novice)
     case .Apprentice:
       return TKMSRSStageCategoryName(.apprentice)
     case .Guru:
@@ -45,8 +42,6 @@ enum PieSlice: Int {
       return UIColor(white: 0.8, alpha: 1.0)
     case .Lesson:
       return UIColor(white: 0.6, alpha: 1.0)
-    case .Novice:
-      saturationMod = 0.4
     case .Apprentice:
       saturationMod = 0.6
     default:
@@ -178,8 +173,6 @@ class CurrentLevelChartCell: TKMModelCell {
         slice = .Lesson
       } else if !assignment.hasSrsStage {
         slice = .Locked
-      } else if assignment.srsStage <= 1 {
-        slice = .Novice
       } else if assignment.srsStage < 5 {
         slice = .Apprentice
       } else {

--- a/ios/proto/Wanikani+Convenience.h
+++ b/ios/proto/Wanikani+Convenience.h
@@ -33,12 +33,11 @@ extern NSString *TKMDetailedSRSStageName(int srsStage);
 NSTimeInterval TKMMinimumTimeUntilGuruSeconds(int itemLevel, int srsStage);
 
 typedef NS_ENUM(NSInteger, TKMSRSStageCategory) {
-  TKMSRSStageNovice = 0,
-  TKMSRSStageApprentice = 1,
-  TKMSRSStageGuru = 2,
-  TKMSRSStageMaster = 3,
-  TKMSRSStageEnlightened = 4,
-  TKMSRSStageBurned = 5,
+  TKMSRSStageApprentice = 0,
+  TKMSRSStageGuru = 1,
+  TKMSRSStageMaster = 2,
+  TKMSRSStageEnlightened = 3,
+  TKMSRSStageBurned = 4,
 };
 extern TKMSRSStageCategory TKMSRSStageCategoryForStage(int srsStage);
 extern int TKMFirstSRSStageInCategory(TKMSRSStageCategory category);

--- a/ios/proto/Wanikani+Convenience.m
+++ b/ios/proto/Wanikani+Convenience.m
@@ -33,7 +33,6 @@ NSString *TKMSubjectTypeName(TKMSubject_Type subjectType) {
 TKMSRSStageCategory TKMSRSStageCategoryForStage(int srsStage) {
   switch (srsStage) {
     case 1:
-      return TKMSRSStageNovice;
     case 2:
     case 3:
     case 4:
@@ -48,16 +47,14 @@ TKMSRSStageCategory TKMSRSStageCategoryForStage(int srsStage) {
     case 9:
       return TKMSRSStageBurned;
     default:
-      return TKMSRSStageNovice;
+      return TKMSRSStageApprentice;
   }
 }
 
 extern int TKMFirstSRSStageInCategory(TKMSRSStageCategory category) {
   switch (category) {
-    case TKMSRSStageNovice:
-      return 1;
     case TKMSRSStageApprentice:
-      return 2;
+      return 1;
     case TKMSRSStageGuru:
       return 5;
     case TKMSRSStageMaster:
@@ -77,7 +74,6 @@ extern NSString *TKMSRSStageCategoryName(TKMSRSStageCategory category) {
 NSString *TKMSRSStageName(int srsStage) {
   switch (srsStage) {
     case 1:
-      return @"Novice";
     case 2:
     case 3:
     case 4:
@@ -98,13 +94,13 @@ NSString *TKMSRSStageName(int srsStage) {
 NSString *TKMDetailedSRSStageName(int srsStage) {
   switch (srsStage) {
     case 1:
-      return @"Novice";
-    case 2:
       return @"Apprentice I";
-    case 3:
+    case 2:
       return @"Apprentice II";
-    case 4:
+    case 3:
       return @"Apprentice III";
+    case 4:
+      return @"Apprentice IV";
     case 5:
       return @"Guru I";
     case 6:


### PR DESCRIPTION
To match with other resources, fix #224, and to allow former "Novice" items to be in the SRS stages list, this commit proposes to rename SRS stages 1-4 back to Apprentice 1-4, like on WK.