### PR TITLE
Add Option to Show All Readings

### DIFF
--- a/ios/Settings.h
+++ b/ios/Settings.h
@@ -63,6 +63,7 @@ DECLARE_BOOL(enableCheats);
 DECLARE_BOOL(showOldMnemonic);
 DECLARE_BOOL(useKatakanaForOnyomi);
 DECLARE_BOOL(showSRSLevelIndicator);
+DECLARE_BOOL(showAllReadings);
 DECLARE_FLOAT(fontSize);
 
 // Offline audio.

--- a/ios/Settings.m
+++ b/ios/Settings.m
@@ -121,6 +121,7 @@ DEFINE_BOOL(enableCheats, setEnableCheats, YES);
 DEFINE_BOOL(showOldMnemonic, setShowOldMnemonic, YES);
 DEFINE_BOOL(useKatakanaForOnyomi, setUseKatakanaForOnyomi, NO);
 DEFINE_BOOL(showSRSLevelIndicator, setShowSRSLevelIndicator, NO);
+DEFINE_BOOL(showAllReadings, setShowAllReadings, NO);
 DEFINE_FLOAT(fontSize, setFontSize, 1.0);
 
 DEFINE_BOOL(playAudioAutomatically, setPlayAudioAutomatically, NO);

--- a/ios/SettingsViewController.m
+++ b/ios/SettingsViewController.m
@@ -162,6 +162,12 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
                                                         on:Settings.showSRSLevelIndicator
                                                     target:self
                                                     action:@selector(showSRSLevelIndicator:)]];
+  [model addItem:[[TKMSwitchModelItem alloc] initWithStyle:UITableViewCellStyleSubtitle
+                                                     title:@"Show all kanji readings"
+                                                  subtitle:@"Primary reading(s) will be shown in bold"
+                                                        on:Settings.showAllReadings
+                                                    target:self
+                                                    action:@selector(showAllReadings:)]];
 
   [model addSection:@"Audio"];
   [model addItem:[[TKMSwitchModelItem alloc]
@@ -313,6 +319,10 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
 
 - (void)showSRSLevelIndicator:(UISwitch *)switchView {
   Settings.showSRSLevelIndicator = switchView.on;
+}
+
+- (void)showAllReadings:(UISwitch *)switchView {
+  Settings.showAllReadings = switchView.on;
 }
 
 - (void)playAudioAutomaticallySwitchChanged:(UISwitch *)switchView {

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -68,7 +68,11 @@ private func renderReadings(readings: [TKMReading], primaryOnly: Bool) -> NSAttr
   var strings = [NSAttributedString]()
   for reading in readings {
     if reading.isPrimary {
-      strings.append(attrString(reading.displayText))
+      var font = TKMStyle.japaneseFontLight(size: kFontSize)
+      if !primaryOnly, readings.count > 1 {
+        font = TKMStyle.japaneseFontBold(size: kFontSize)
+      }
+      strings.append(attrString(reading.displayText, attrs: [.font: font]))
     }
   }
   if !primaryOnly {
@@ -139,7 +143,7 @@ class SubjectDetailsView: UITableView, TKMSubjectChipDelegate {
   }
 
   private func addReadings(_ subject: TKMSubject, toModel model: TKMMutableTableModel) {
-    let primaryOnly = subject.hasKanji
+    let primaryOnly = !Settings.showAllReadings
 
     let text = renderReadings(readings: subject.readingsArray as! [TKMReading], primaryOnly: primaryOnly).withFontSize(kFontSize)
     let item = TKMReadingModelItem(text: text)


### PR DESCRIPTION
Implements https://github.com/davidsansome/tsurukame/issues/230
* Unless requested, I opted not to make separate sections for each type of reading as @sciencemanx brought up a good point about it potentially taking up too much room before getting to the "meat" of the entry/subject.
* Primary readings are always first. If more that one reading exists, the primary one(s) will be in bold.

### Added new user option (default is false):
<img src="https://user-images.githubusercontent.com/20361890/71335815-5b926980-24f9-11ea-88be-154a9744f6d6.png" width=400 />

### When option is flipped on:
* Kanji/Vocabulary with multiple readings
<img src="https://user-images.githubusercontent.com/20361890/71335976-220e2e00-24fa-11ea-91e9-0f6b5f453d32.png"  width=400 />
<img src="https://user-images.githubusercontent.com/20361890/71336007-4bc75500-24fa-11ea-8c16-21387ce8a390.png"  width=400 />


* Kanji/Vocabulary with one reading (functions the same as today)
<img src="https://user-images.githubusercontent.com/20361890/71335958-09057d00-24fa-11ea-94e5-bb320164969f.png" width=400 />
<img src="https://user-images.githubusercontent.com/20361890/71336048-6c8faa80-24fa-11ea-974d-9e5f2f7fde08.png" width=400 />

* No changes in radicals

### When option is off:
* No changes