### PR TITLE
Check how long until radical guru (Fixes #222)

### DIFF
--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -82,10 +82,8 @@ class LevelTimeRemainingCell: TKMModelCell {
     }
 
     // Sort the list of dates and remove the most distant 10%.
-    guruDates.sort()
-    guruDates.removeLast(Int(Double(guruDates.count) * 0.1))
-    levels = Array(levels.sorted().reversed())
-    levels.removeLast(Int(Double(levels.count) * 0.1))
+    guruDates = guruDates.sorted().removeLast(Int(Double(guruDates.count) * 0.1))
+    levels = Array(levels.sorted().reversed()).removeLast(Int(Double(levels.count) * 0.1))
 
     if let lastGuruDate = guruDates.last, lastKanjiLevel = levels.last {
       if lastGuruDate == Date.distantFuture {
@@ -97,7 +95,6 @@ class LevelTimeRemainingCell: TKMModelCell {
         // But ensure it can't be less than the time it would take to get a fresh item
         // to Guru, if they've spent longer at the current level than the average.
         average = max(average, TKMMinimumTimeUntilGuruSeconds(lastKanjiLevel, 1) + lastRadicalGuruTime)
-
         setRemaining(Date(timeIntervalSinceNow: average), isEstimate: true)
       } else {
         setRemaining(lastGuruDate, isEstimate: false)

--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -63,7 +63,8 @@ class LevelTimeRemainingCell: TKMModelCell {
       }
       radicalDates.append(assignment.guruDate(for: subject))
     }
-    let lastRadicalGuruTime = radicalDates.last?.timeIntervalSinceNow ?? 0
+    radicalDates.sort()
+    let lastRadicalGuruTime = max(radicalDates.last?.timeIntervalSinceNow ?? 0, 0)
 
     for assignment in item.currentLevelAssignments {
       if assignment.subjectType != .kanji {
@@ -83,9 +84,9 @@ class LevelTimeRemainingCell: TKMModelCell {
 
     // Sort the list of dates and remove the most distant 10%.
     guruDates = Array(guruDates.sorted().dropLast(Int(Double(guruDates.count) * 0.1)))
-    levels = Array(Array(levels.sorted().reversed()).dropLast(Int(Double(levels.count) * 0.1)))
+    levels = Array(levels.sorted(by: >).dropLast(Int(Double(levels.count) * 0.1)))
 
-    if let lastGuruDate = guruDates.last, let WKLevel = levels.last {
+    if let lastGuruDate = guruDates.last, let wkLevel = levels.last {
       if lastGuruDate == Date.distantFuture {
         // There is still a locked kanji needed for level-up, so we don't know how long
         // the user will take to level up. Use their average level time, minus the time
@@ -93,7 +94,7 @@ class LevelTimeRemainingCell: TKMModelCell {
         var average = item.services.localCachingClient!.getAverageRemainingLevelTime()
         // But ensure it can't be less than the time it would take to get a fresh item
         // to Guru, if they've spent longer at the current level than the average.
-        average = max(average, TKMMinimumTimeUntilGuruSeconds(WKLevel, 1) + lastRadicalGuruTime)
+        average = max(average, TKMMinimumTimeUntilGuruSeconds(wkLevel, 1) + lastRadicalGuruTime)
         setRemaining(Date(timeIntervalSinceNow: average), isEstimate: true)
       } else {
         setRemaining(lastGuruDate, isEstimate: false)

--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -63,8 +63,7 @@ class LevelTimeRemainingCell: TKMModelCell {
       }
       radicalDates.append(assignment.guruDate(for: subject))
     }
-    var lastRadicalGuruTime = radicalDates.last!.timeIntervalSinceNow
-    lastRadicalGuruTime = lastRadicalGuruTime > 0 ? lastRadicalGuruTime : 0
+    var lastRadicalGuruTime = radicalDates.last?.timeIntervalSinceNow ?? 0
 
     for assignment in item.currentLevelAssignments {
       if assignment.subjectType != .kanji {
@@ -88,8 +87,8 @@ class LevelTimeRemainingCell: TKMModelCell {
     levels = Array(levels.sorted().reversed())
     levels.removeLast(Int(Double(levels.count) * 0.1))
 
-    if let lastDate = guruDates.last {
-      if lastDate == Date.distantFuture {
+    if let lastGuruDate = guruDates.last, lastKanjiLevel = levels.last {
+      if lastGuruDate == Date.distantFuture {
         // There is still a locked kanji needed for level-up, so we don't know how long
         // the user will take to level up.  Use their average level time, minus the time
         // they've spent at this level so far, as an estimate.
@@ -97,12 +96,11 @@ class LevelTimeRemainingCell: TKMModelCell {
 
         // But ensure it can't be less than the time it would take to get a fresh item
         // to Guru, if they've spent longer at the current level than the average.
-        average = max(average, TKMMinimumTimeUntilGuruSeconds(levels.last!, 1) + lastRadicalGuruTime)
+        average = max(average, TKMMinimumTimeUntilGuruSeconds(lastKanjiLevel, 1) + lastRadicalGuruTime)
 
         setRemaining(Date(timeIntervalSinceNow: average), isEstimate: true)
-      }
-      else {
-        setRemaining(lastDate, isEstimate: false)
+      } else {
+        setRemaining(lastGuruDate, isEstimate: false)
       }
     }
   }

--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -82,8 +82,8 @@ class LevelTimeRemainingCell: TKMModelCell {
     }
 
     // Sort the list of dates and remove the most distant 10%.
-    guruDates = guruDates.sorted().removeLast(Int(Double(guruDates.count) * 0.1))
-    levels = Array(levels.sorted().reversed()).removeLast(Int(Double(levels.count) * 0.1))
+    guruDates = Array(guruDates.sorted().dropLast(Int(Double(guruDates.count) * 0.1)))
+    levels = Array(Array(levels.sorted().reversed()).dropLast(Int(Double(levels.count) * 0.1)))
 
     if let lastGuruDate = guruDates.last, let lastKanjiLevel = levels.last {
       if lastGuruDate == Date.distantFuture {

--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -49,9 +49,19 @@ class LevelTimeRemainingCell: TKMModelCell {
 
   override func update(with baseItem: TKMModelItem!) {
     let item = baseItem as! LevelTimeRemainingItem
-
+    
+    var radicalDates = [Date]()
     var guruDates = [Date]()
-
+    
+    for assignment in item.currentLevelAssignments {
+      if assignment.subjectType != .radical {
+        continue
+      }
+      radicalDates.append(assignment.guruDate(for: subject))
+    }
+    var lastRadicalGuruTime = radicalDates.last.timeIntervalSinceNow
+    lastRadicalGuruTime = lastRadicalGuruTime > 0 ? lastRadicalGuruTime : 0
+    
     for assignment in item.currentLevelAssignments {
       if assignment.subjectType != .kanji {
         continue
@@ -65,7 +75,7 @@ class LevelTimeRemainingCell: TKMModelCell {
 
         // But ensure it can't be less than the time it would take to get a fresh item
         // to Guru, if they've spent longer at the current level than the average.
-        average = max(average, TKMMinimumTimeUntilGuruSeconds(assignment.level, 1))
+        average = max(average, TKMMinimumTimeUntilGuruSeconds(assignment.level, 1) + lastRadicalGuruTime)
 
         setRemaining(Date(timeIntervalSinceNow: average), isEstimate: true)
         return

--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -49,11 +49,11 @@ class LevelTimeRemainingCell: TKMModelCell {
 
   override func update(with baseItem: TKMModelItem!) {
     let item = baseItem as! LevelTimeRemainingItem
-    
+
     var radicalDates = [Date]()
     var guruDates = [Date]()
     var levels = [Int32]()
-    
+ 
     for assignment in item.currentLevelAssignments {
       if assignment.subjectType != .radical {
         continue
@@ -65,7 +65,7 @@ class LevelTimeRemainingCell: TKMModelCell {
     }
     var lastRadicalGuruTime = radicalDates.last!.timeIntervalSinceNow
     lastRadicalGuruTime = lastRadicalGuruTime > 0 ? lastRadicalGuruTime : 0
-    
+
     for assignment in item.currentLevelAssignments {
       if assignment.subjectType != .kanji {
         continue
@@ -85,9 +85,9 @@ class LevelTimeRemainingCell: TKMModelCell {
     // Sort the list of dates and remove the most distant 10%.
     guruDates.sort()
     guruDates.removeLast(Int(Double(guruDates.count) * 0.1))
-    levels.sort().reversed()
+    levels = Array(levels.sorted().reversed())
     levels.removeLast(Int(Double(levels.count) * 0.1))
-    
+
     if let lastDate = guruDates.last {
       if lastDate == Date.distantFuture {
         // There is still a locked kanji needed for level-up, so we don't know how long

--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -52,7 +52,7 @@ class LevelTimeRemainingCell: TKMModelCell {
     
     var radicalDates = [Date]()
     var guruDates = [Date]()
-    var levels = [Int]()
+    var levels = [Int32]()
     
     for assignment in item.currentLevelAssignments {
       if assignment.subjectType != .radical {
@@ -63,7 +63,7 @@ class LevelTimeRemainingCell: TKMModelCell {
       }
       radicalDates.append(assignment.guruDate(for: subject))
     }
-    var lastRadicalGuruTime = radicalDates.last.timeIntervalSinceNow
+    var lastRadicalGuruTime = radicalDates.last!.timeIntervalSinceNow
     lastRadicalGuruTime = lastRadicalGuruTime > 0 ? lastRadicalGuruTime : 0
     
     for assignment in item.currentLevelAssignments {
@@ -85,6 +85,8 @@ class LevelTimeRemainingCell: TKMModelCell {
     // Sort the list of dates and remove the most distant 10%.
     guruDates.sort()
     guruDates.removeLast(Int(Double(guruDates.count) * 0.1))
+    levels.sort().reversed()
+    levels.removeLast(Int(Double(levels.count) * 0.1))
     
     if let lastDate = guruDates.last {
       if lastDate == Date.distantFuture {
@@ -95,7 +97,7 @@ class LevelTimeRemainingCell: TKMModelCell {
 
         // But ensure it can't be less than the time it would take to get a fresh item
         // to Guru, if they've spent longer at the current level than the average.
-        average = max(average, TKMMinimumTimeUntilGuruSeconds(0, 1) + lastRadicalGuruTime)
+        average = max(average, TKMMinimumTimeUntilGuruSeconds(levels.last!, 1) + lastRadicalGuruTime)
 
         setRemaining(Date(timeIntervalSinceNow: average), isEstimate: true)
       }

--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -85,13 +85,12 @@ class LevelTimeRemainingCell: TKMModelCell {
     guruDates = guruDates.sorted().removeLast(Int(Double(guruDates.count) * 0.1))
     levels = Array(levels.sorted().reversed()).removeLast(Int(Double(levels.count) * 0.1))
 
-    if let lastGuruDate = guruDates.last, lastKanjiLevel = levels.last {
+    if let lastGuruDate = guruDates.last, let lastKanjiLevel = levels.last {
       if lastGuruDate == Date.distantFuture {
         // There is still a locked kanji needed for level-up, so we don't know how long
-        // the user will take to level up.  Use their average level time, minus the time
+        // the user will take to level up. Use their average level time, minus the time
         // they've spent at this level so far, as an estimate.
         var average = item.services.localCachingClient!.getAverageRemainingLevelTime()
-
         // But ensure it can't be less than the time it would take to get a fresh item
         // to Guru, if they've spent longer at the current level than the average.
         average = max(average, TKMMinimumTimeUntilGuruSeconds(lastKanjiLevel, 1) + lastRadicalGuruTime)


### PR DESCRIPTION
To attempt to fix #222, this code attempts to check the last radical guru time if a kanji is still locked.

**EDIT:** Thanks for helping with CircleCI! I was trying to work on this issue on vacation, so I couldn't use my computer to test the builds.