### PR TITLE
Stop lessons from higher levels appearing

### DIFF
--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -266,8 +266,8 @@ class MainViewController: UITableViewController, LoginViewControllerDelegate,
     case "startLessons":
       let assignments = services.localCachingClient.getAllAssignments()
       var items = ReviewItem.assignmentsReady(forLesson: assignments,
-                                              dataLoader: services.dataLoader)
-
+                                              dataLoader: services.dataLoader,
+                                              localCachingClient: services.localCachingClient)
       if items.count == 0 {
         return
       }

--- a/ios/ReviewItem.h
+++ b/ios/ReviewItem.h
@@ -34,7 +34,8 @@ typedef NS_ENUM(NSInteger, TKMTaskType) {
                                           dataLoader:(DataLoader *)dataLoader
                                   localCachingClient:(LocalCachingClient *)localCachingClient;
 + (NSArray<ReviewItem *> *)assignmentsReadyForLesson:(NSArray<TKMAssignment *> *)assignments
-                                          dataLoader:(DataLoader *)dataLoader;
+                                          dataLoader:(DataLoader *)dataLoader
+                                  localCachingClient:(LocalCachingClient *)localCachingClient;
 
 - (NSUInteger)getSubjectTypeIndex:(TKMSubject_Type)type;
 

--- a/ios/ReviewItem.m
+++ b/ios/ReviewItem.m
@@ -41,10 +41,16 @@
 }
 
 + (NSArray<ReviewItem *> *)assignmentsReadyForLesson:(NSArray<TKMAssignment *> *)assignments
-                                          dataLoader:(DataLoader *)dataLoader {
+                                          dataLoader:(DataLoader *)dataLoader
+                                  localCachingClient:(LocalCachingClient *)localCachingClient {
   NSMutableArray *ret = [NSMutableArray array];
+  TKMUser *userInfo = [localCachingClient getUserInfo];
   for (TKMAssignment *assignment in assignments) {
     if (![dataLoader isValidSubjectID:assignment.subjectId]) {
+      continue;
+    }
+
+    if (userInfo.hasLevel && userInfo.level < assignment.level) {
       continue;
     }
 


### PR DESCRIPTION
This further addresses the problem where the 'hills' radical was always being shown in lessons for some users.

See #324 and #338.