### PR TITLE
Longest Relative Wait Order (Fixes #355)

### DIFF
--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -744,6 +744,23 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Descending SRS stage" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pJV-Uz-Mja">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="10" textLabel="xdt-el-vHI" style="IBUITableViewCellStyleDefault" id="XyJ-Ed-qxo">
+                                        <rect key="frame" x="0.0" y="336" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="XyJ-Ed-qxo" id="EIK-1l-yOs">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Longest relative wait" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xdt-el-vHI">
                                                     <rect key="frame" x="16" y="0.0" width="343" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>

--- a/ios/Settings.h
+++ b/ios/Settings.h
@@ -35,6 +35,7 @@ typedef NS_ENUM(NSUInteger, ReviewOrder) {
   ReviewOrder_NewestAvailableFirst = 5,
   ReviewOrder_OldestAvailableFirst = 6,
   ReviewOrder_DescendingSRSStage = 7,
+  ReviewOrder_LongestRelativeWait = 8,
 };
 
 typedef NS_CLOSED_ENUM(NSUInteger, InterfaceStyle){

--- a/ios/SettingsViewController.m
+++ b/ios/SettingsViewController.m
@@ -156,8 +156,8 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
                                                 action:@selector(fontSizeChanged:)]];
 
   [model addItem:[[TKMSwitchModelItem alloc] initWithStyle:UITableViewCellStyleSubtitle
-                                                     title:@"Allow cheating"
-                                                  subtitle:@"Ignore Typos and Add Synonym"
+                                                     title:@"Ignore Typos & Add Synonym"
+                                                  subtitle:nil
                                                         on:Settings.enableCheats
                                                     target:self
                                                     action:@selector(enableCheatsSwitchChanged:)]];

--- a/ios/SettingsViewController.m
+++ b/ios/SettingsViewController.m
@@ -298,6 +298,8 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
       return @"Newest available first";
     case ReviewOrder_OldestAvailableFirst:
       return @"Oldest available first";
+    case ReviewOrder_LongestRelativeWait:
+      return @"Longest relative wait";
   }
   return nil;
 }

--- a/ios/TKMReviewMenuViewController.m
+++ b/ios/TKMReviewMenuViewController.m
@@ -37,7 +37,7 @@
   [model addSection:@"Quick settings"];
   [model
       addItem:[[TKMCheckmarkModelItem alloc] initWithStyle:UITableViewCellStyleDefault
-                                                     title:@"Allow cheating"
+                                                     title:@"Ignore Typos & Add Synonym"
                                                   subtitle:nil
                                                         on:Settings.enableCheats
                                                     target:self


### PR DESCRIPTION
Fixes #355 by adding longest relative wait order.

This PR also changes the user-displayed name of "Allow Cheating" to "Ignore Typos & Add Synonyms" since skipping reviews (introduced in #300) clearly also is cheating but isn't part of this setting.