### PR TITLE
Change auto-reveal condition (Fix #321)

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1135,7 +1135,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
     }
 
     // Otherwise show the correct answer.
-    if !Settings.showAnswerImmediately, firstTimeAnswered {
+    if !Settings.showAnswerImmediately {
       revealAnswerButton.isHidden = false
       UIView.animate(withDuration: animationDuration,
                      animations: {


### PR DESCRIPTION
Fix #321. If the setting is off, we should never reveal it automatically, and if it's on, we should always reveal automatically.