### PR TITLE
Set the subject details view to be first responder when needed

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -390,14 +390,18 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
     if subjectDetailsView.isHidden {
       answerField.becomeFirstResponder()
       answerField.reloadInputViews()
+    } else {
+      subjectDetailsView.becomeFirstResponder()
     }
   }
 
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     subjectDetailsView.deselectLastSubjectChipTapped()
-    DispatchQueue.main.async {
-      self.focusAnswerField()
+    if subjectDetailsView.isHidden {
+      DispatchQueue.main.async {
+        self.focusAnswerField()
+      }
     }
   }
 


### PR DESCRIPTION
This treats the case where a SubjectDetailsView can lose its keyboard focus during navigation events in reviews, and the expected keyboard commands do not work.

Fixes #369.