### PR TITLE
Hide summary & add stats section

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -172,6 +172,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
   private var activeTask: ReviewItem!
   private var activeSubject: TKMSubject!
   private var activeStudyMaterials: TKMStudyMaterials?
+  private var activeAssignment: TKMAssignment?
 
   @objc public private(set) var tasksAnsweredCorrectly = 0
   private var tasksAnswered = 0
@@ -522,6 +523,8 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
       activeSubject = services.dataLoader.load(subjectID: Int(activeTask.assignment.subjectId))!
       activeStudyMaterials =
         services.localCachingClient.getStudyMaterial(forID: activeTask.assignment.subjectId)
+      activeAssignment =
+        services.localCachingClient.getAssignmentForID(activeTask.assignment.subjectId)
 
       // Choose whether to ask the meaning or the reading.
       if activeTask.answeredMeaning {
@@ -1166,7 +1169,8 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
   }
 
   @IBAction func revealAnswerButtonPressed(_: Any) {
-    subjectDetailsView.update(withSubject: activeSubject, studyMaterials: activeStudyMaterials)
+    subjectDetailsView.update(withSubject: activeSubject, studyMaterials: activeStudyMaterials,
+                              assignment: activeAssignment, task: activeTask)
 
     let setupContextFunc = { (ctx: AnimationContext) in
       if self.questionLabel.font.familyName != self.normalFontName {

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -114,8 +114,7 @@ private func dateFormatter(dateStyle: DateFormatter.Style,
 
 @objc(TKMSubjectDetailsView)
 class SubjectDetailsView: UITableView, TKMSubjectChipDelegate {
-  private let availableDateFormatter = dateFormatter(dateStyle: .medium, timeStyle: .medium)
-  private let startedDateFormatter = dateFormatter(dateStyle: .medium, timeStyle: .none)
+  private let statsDateFormatter = dateFormatter(dateStyle: .medium, timeStyle: .medium)
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
@@ -270,23 +269,29 @@ class SubjectDetailsView: UITableView, TKMSubjectChipDelegate {
     model.add(item)
   }
 
-  @objc public func update(withSubject subject: TKMSubject, studyMaterials: TKMStudyMaterials?) {
-    let model = TKMMutableTableModel(tableView: self)
+  @objc public func update(withSubject subject: TKMSubject, studyMaterials: TKMStudyMaterials?,
+                           assignment: TKMAssignment?, task: ReviewItem?) {
+    let model = TKMMutableTableModel(tableView: self), isReview = task != nil
     readingItem = nil
+    let meaningAttempted = task?.answeredMeaning == true || task?.answer.meaningWrong == true
+    let readingAttempted = subject.hasRadical == true || task?.answeredReading == true ||
+      task?.answer.readingWrong == true
 
     if subject.hasRadical {
       addMeanings(subject, studyMaterials: studyMaterials, toModel: model)
 
-      model.addSection("Mnemonic")
-      addFormattedText(subject.radical.formattedMnemonicArray as! [TKMFormattedText], isHint: false,
-                       toModel: model)
+      if !isReview || meaningAttempted {
+        model.addSection("Mnemonic")
+        addFormattedText(subject.radical.formattedMnemonicArray as! [TKMFormattedText],
+                         isHint: false,
+                         toModel: model)
 
-      if Settings.showOldMnemonic, subject.radical!.formattedDeprecatedMnemonicArray_Count != 0 {
-        model.addSection("Old Mnemonic")
-        addFormattedText(subject.radical.formattedDeprecatedMnemonicArray as! [TKMFormattedText],
-                         isHint: false, toModel: model)
+        if Settings.showOldMnemonic, subject.radical!.formattedDeprecatedMnemonicArray_Count != 0 {
+          model.addSection("Old Mnemonic")
+          addFormattedText(subject.radical.formattedDeprecatedMnemonicArray as! [TKMFormattedText],
+                           isHint: false, toModel: model)
+        }
       }
-
       addAmalgamationSubjects(subject, toModel: model)
     }
     if subject.hasKanji {
@@ -294,18 +299,22 @@ class SubjectDetailsView: UITableView, TKMSubjectChipDelegate {
       addReadings(subject, studyMaterials: studyMaterials, toModel: model)
       addComponents(subject, title: "Radicals", toModel: model)
 
-      model.addSection("Meaning Explanation")
-      addFormattedText(subject.kanji.formattedMeaningMnemonicArray as! [TKMFormattedText],
-                       isHint: false, toModel: model)
-      addFormattedText(subject.kanji.formattedMeaningHintArray as! [TKMFormattedText], isHint: true,
-                       toModel: model)
-
-      model.addSection("Reading Explanation")
-      addFormattedText(subject.kanji.formattedReadingMnemonicArray as! [TKMFormattedText],
-                       isHint: false, toModel: model)
-      addFormattedText(subject.kanji.formattedReadingHintArray as! [TKMFormattedText], isHint: true,
-                       toModel: model)
-
+      if !isReview || meaningAttempted {
+        model.addSection("Meaning Explanation")
+        addFormattedText(subject.kanji.formattedMeaningMnemonicArray as! [TKMFormattedText],
+                         isHint: false, toModel: model)
+        addFormattedText(subject.kanji.formattedMeaningHintArray as! [TKMFormattedText],
+                         isHint: true,
+                         toModel: model)
+      }
+      if !isReview || readingAttempted {
+        model.addSection("Reading Explanation")
+        addFormattedText(subject.kanji.formattedReadingMnemonicArray as! [TKMFormattedText],
+                         isHint: false, toModel: model)
+        addFormattedText(subject.kanji.formattedReadingHintArray as! [TKMFormattedText],
+                         isHint: true,
+                         toModel: model)
+      }
       addSimilarKanji(subject, toModel: model)
       addAmalgamationSubjects(subject, toModel: model)
     }
@@ -314,19 +323,46 @@ class SubjectDetailsView: UITableView, TKMSubjectChipDelegate {
       addReadings(subject, studyMaterials: studyMaterials, toModel: model)
       addComponents(subject, title: "Kanji", toModel: model)
 
-      model.addSection("Meaning Explanation")
-      addFormattedText(subject.vocabulary.formattedMeaningExplanationArray as! [TKMFormattedText],
-                       isHint: false, toModel: model)
-
-      model.addSection("Reading Explanation")
-      addFormattedText(subject.vocabulary.formattedReadingExplanationArray as! [TKMFormattedText],
-                       isHint: false, toModel: model)
-
+      if !isReview || meaningAttempted {
+        model.addSection("Meaning Explanation")
+        addFormattedText(subject.vocabulary.formattedMeaningExplanationArray as! [TKMFormattedText],
+                         isHint: false, toModel: model)
+      }
+      if !isReview || readingAttempted {
+        model.addSection("Reading Explanation")
+        addFormattedText(subject.vocabulary.formattedReadingExplanationArray as! [TKMFormattedText],
+                         isHint: false, toModel: model)
+      }
       addPartsOfSpeech(subject.vocabulary, toModel: model)
-      addContextSentences(subject, toModel: model)
+      if !isReview || meaningAttempted {
+        addContextSentences(subject, toModel: model)
+      }
     }
 
-    // TODO: Your progress, SRS level, next review, first started, reached guru
+    // Your progress, SRS level, next review, first started, reached guru
+    if let subjectAssignment = assignment {
+      model.addSection("Stats")
+      var statString = "WK Level: \(subjectAssignment.level)"
+      if subjectAssignment.hasStartedAt {
+        statString += "First started at: " + statsDateFormatter
+          .string(from: subjectAssignment.startedAtDate)
+        if subjectAssignment.hasSrsStage {
+          statString += "\nSRS stage: " + TKMDetailedSRSStageName(subjectAssignment.srsStage)
+        }
+        if subjectAssignment.hasAvailableAt {
+          statString += "\nNext review at: " + statsDateFormatter
+            .string(from: subjectAssignment.availableAtDate)
+        }
+        if subjectAssignment.hasPassedAt {
+          statString += "\nPassed at: " + statsDateFormatter
+            .string(from: subjectAssignment.passedAtDate)
+        }
+      }
+      let font = UIFont.systemFont(ofSize: kFontSize, weight: .regular)
+      model.add(AttributedModelItem(text: attrString(statString, attrs: [.font: font])))
+
+      // TODO: When possible in the API, add a resurrect button.
+    }
 
     tableModel = model
     model.reloadTable()

--- a/ios/SubjectDetailsViewController.m
+++ b/ios/SubjectDetailsViewController.m
@@ -65,7 +65,11 @@
 
   TKMStudyMaterials *studyMaterials =
       [_services.localCachingClient getStudyMaterialForID:_subject.id_p];
-  [_subjectDetailsView updateWithSubject:_subject studyMaterials:studyMaterials];
+  TKMAssignment *assignment = [_services.localCachingClient getAssignmentForID:_subject.id_p];
+  [_subjectDetailsView updateWithSubject:_subject
+                          studyMaterials:studyMaterials
+                              assignment:assignment
+                                    task:nil];
 
   _subjectTitle.font = [TKMStyle japaneseFontWithSize:_subjectTitle.font.pointSize];
   _subjectTitle.attributedText = [_subject japaneseTextWithImageSize:40.f];


### PR DESCRIPTION
This PR fixes #49 by hiding parts of an answer during reviews that haven't been attempted yet, and the last answered review pop-up will now be shown for half-answered reviews due to this being fixed. _(Side note: This may not be an ideal solution since there is no way to see the correct answer if you want to. You may want to explore the possibility of re-introducing the blurring.)_

This PR also partially addresses #257 by adding the stats section, but it doesn't add a resurrect button since the API [hasn't exposed an endpoint for that yet.](https://community.wanikani.com/t/official-announcement-on-upcoming-api-version-2-breaking-changes-addition-of-new-endpoint-spacedrepetitionsystems/44423/73)