### PR TITLE
Add safeguard to prevent setting wipe from old format (Fixes #388)

### DIFF
--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -52,6 +52,9 @@ import Foundation
 
   var wrappedValue: T {
     get {
+      if let notEncodedObject = UserDefaults.standard.object(forKey: key) as? T {
+        return notEncodedObject
+      }
       guard let data = UserDefaults.standard.object(forKey: key) as? Data
       else { return defaultValue }
       return (try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? T) ?? defaultValue


### PR DESCRIPTION
Based on #388, this PR should theoretically prevent loss of settings from before the Swift conversion.

To test this after merging, set settings that were not previously encoded with NSKeyedArchiver (such as font size, review order, etc.) on TestFlight build 309, then upgrade to a not yet extant TestFlight build containing this commit.