### PR TITLE
Correct not encoded settings (Fixes #398)

### DIFF
--- a/ios/InterfaceStyleViewController.swift
+++ b/ios/InterfaceStyleViewController.swift
@@ -18,7 +18,7 @@ class InterfaceStyleViewController: UITableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    var selectedRow = Int(Settings.interfaceStyle.rawValue - 1)
+    var selectedRow = Int(Settings.interfaceStyle - 1)
     if selectedRow < 0 || selectedRow >= tableView.numberOfRows(inSection: 0) {
       selectedRow = 0
     }
@@ -29,8 +29,8 @@ class InterfaceStyleViewController: UITableViewController {
   }
 
   override func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
-    Settings.interfaceStyle = InterfaceStyle(rawValue: UInt(indexPath.row + 1))!
-    view.window!.setInterfaceStyle(Settings.interfaceStyle)
+    Settings.interfaceStyle = UInt(indexPath.row + 1)
+    view.window!.setInterfaceStyle(InterfaceStyle(rawValue: Settings.interfaceStyle)!)
     navigationController?.popViewController(animated: true)
   }
 }

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -246,7 +246,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
     }
 
     reviewQueue.shuffle()
-    switch Settings.reviewOrder {
+    switch ReviewOrder(rawValue: Settings.reviewOrder)! {
     case .ascendingSRSStage:
       reviewQueue.sort { (a, b: ReviewItem) -> Bool in
         if a.assignment.srsStage < b.assignment.srsStage { return true }

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -52,11 +52,15 @@ import Foundation
 
   var wrappedValue: T {
     get {
+      // Encode anything not encoded
       if let notEncodedObject = UserDefaults.standard.object(forKey: key) as? T {
-        return notEncodedObject
+        UserDefaults.standard.set(archiveData(notEncodedObject), forKey: key)
       }
-      guard let data = UserDefaults.standard.object(forKey: key) as? Data
-      else { return defaultValue }
+      // Decode value if obtainable and return it
+      guard let data = UserDefaults.standard.object(forKey: key) as? Data else {
+        UserDefaults.standard.set(archiveData(defaultValue), forKey: key)
+        return defaultValue
+      }
       return (try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? T) ?? defaultValue
     }
     set(newValue) { UserDefaults.standard.set(archiveData(newValue), forKey: key) }
@@ -68,7 +72,7 @@ import Foundation
   @Setting("", #keyPath(userEmailAddress)) static var userEmailAddress: String
   @Setting("", #keyPath(userApiToken)) static var userApiToken: String
 
-  @Setting(.system, #keyPath(interfaceStyle)) static var interfaceStyle: InterfaceStyle
+  @Setting(InterfaceStyle.system.rawValue, #keyPath(interfaceStyle)) static var interfaceStyle: UInt
 
   @Setting(false, #keyPath(notificationsAllReviews)) static var notificationsAllReviews: Bool
   @Setting(true, #keyPath(notificationsBadging)) static var notificationsBadging: Bool
@@ -81,7 +85,7 @@ import Foundation
   ], #keyPath(lessonOrder)) static var lessonOrder: [Int32]
   @Setting(5, #keyPath(lessonBatchSize)) static var lessonBatchSize: Int
 
-  @Setting(.random, #keyPath(reviewOrder)) static var reviewOrder: ReviewOrder
+  @Setting(ReviewOrder.random.rawValue, #keyPath(reviewOrder)) static var reviewOrder: UInt
   @Setting(5, #keyPath(reviewBatchSize)) static var reviewBatchSize: Int
   @Setting(false, #keyPath(groupMeaningReading)) static var groupMeaningReading: Bool
   @Setting(true, #keyPath(meaningFirst)) static var meaningFirst: Bool


### PR DESCRIPTION
This PR fixes #398 by reverting the change in storage of enum values, so that the interface style and review order preferences will not be wiped, and encoding any settings which have not been encoded.