### PR TITLE
Add edit meaning/reading notes & show all buttons (Fixes #27, #172, #361)

### DIFF
--- a/ios/SettingsViewController.swift
+++ b/ios/SettingsViewController.swift
@@ -297,7 +297,7 @@ class SettingsViewController: UITableViewController {
   @objc private func prioritizeCurrentLevelChanged(_ switchView: UISwitch) {
     Settings.prioritizeCurrentLevel = switchView.isOn
   }
-  
+
   @objc private func showStatsSectionChanged(_ switchView: UISwitch) {
     Settings.showStatsSection = switchView.isOn
   }


### PR DESCRIPTION
Fixes #172 by adding a button to show meaning & reading, as well as correcting some bugs created in #383.

Also adds edit meaning/reading notes buttons, which fixes #27 and closes #361 (a duplicate), and corrects reading note bug (migrated from #405).