### PR TITLE
Add two additional keyboard commands (Fixes #372)

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1308,6 +1308,12 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
                                         discoverabilityTitle: "Previous font"))
       }
     }
+    if !previousSubjectButton.isHidden {
+      keyCommands.append(UIKeyCommand(input: "p",
+                                      modifierFlags: [],
+                                      action: #selector(previousSubjectButtonPressed(_:)),
+                                      discoverabilityTitle: "Previous subject"))
+    }
     return keyCommands
   }
 

--- a/ios/SubjectDetailsViewController.m
+++ b/ios/SubjectDetailsViewController.m
@@ -122,10 +122,16 @@
 }
 
 - (NSArray<UIKeyCommand *> *)keyCommands {
-  return @[ [UIKeyCommand keyCommandWithInput:@" "
-                                modifierFlags:0
-                                       action:@selector(playAudio)
-                         discoverabilityTitle:@"Play reading"] ];
+  return @[
+    [UIKeyCommand keyCommandWithInput:@" "
+                        modifierFlags:0
+                               action:@selector(playAudio)
+                 discoverabilityTitle:@"Play reading"],
+    [UIKeyCommand keyCommandWithInput:UIKeyInputLeftArrow
+                        modifierFlags:0
+                               action:@selector(backButtonPressed:)
+                 discoverabilityTitle:@"Back"]
+  ];
 }
 
 - (void)playAudio {


### PR DESCRIPTION
Fixes #372 by adding key commands for the previous subject button, and to return back to the review view controller.
These new commands are "p" and the left arrow, respectively.