### PR TITLE
Allow trailing n-kana completion in Gboard Godan layout

### DIFF
--- a/ios/AnswerChecker.swift
+++ b/ios/AnswerChecker.swift
@@ -115,6 +115,10 @@ import Foundation
         .replacingOccurrences(of: "/", with: "")
     if taskType == TKMTaskType.reading {
       s = s.replacingOccurrences(of: "n", with: alphabet == TKMAlphabet.hiragana ? "ん" : "ン")
+        
+      // Gboard Godan layout uses "ｎ" or Unicode code point U+FF4E.
+      s = s.replacingOccurrences(of: "ｎ", with: alphabet == TKMAlphabet.hiragana ? "ん" : "ン")
+                
       s = s.replacingOccurrences(of: " ", with: "")
     }
     return s


### PR DESCRIPTION
This commit enables a single, trailing 'n' entry to be converted to 'ん' on answer submission, to be like other kana input sources, where it otherwise requires entering 'nn' to be complete.

Note that hardware keyboard input on iOS requires two enter presses to complete 'ん' from 'n' with this behavior being the same for other Japanese keyboards.