### PR TITLE
Fix #27 - assign reading note to correct Protobuf field

### DIFF
--- a/ios/Client.m
+++ b/ios/Client.m
@@ -816,7 +816,7 @@ static NSString *GetSessionCookie(NSURLSession *session) {
                          studyMaterials.meaningNote = d[@"data"][@"meaning_note"];
                        }
                        if (d[@"data"][@"reading_note"] != [NSNull null]) {
-                         studyMaterials.meaningNote = d[@"data"][@"reading_note"];
+                         studyMaterials.readingNote = d[@"data"][@"reading_note"];
                        }
                        if (d[@"data"][@"meaning_synonyms"] != [NSNull null]) {
                          studyMaterials.meaningSynonymsArray = d[@"data"][@"meaning_synonyms"];


### PR DESCRIPTION
This issues fixes #27 by setting the reading note to the reading note variable, instead of the meaning note.