### PR TITLE
 Prevent input interference with a modifier for previous subject

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1310,7 +1310,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, TKMSubjectDel
     }
     if !previousSubjectButton.isHidden {
       keyCommands.append(UIKeyCommand(input: "p",
-                                      modifierFlags: [],
+                                      modifierFlags: [.command],
                                       action: #selector(previousSubjectButtonPressed(_:)),
                                       discoverabilityTitle: "Previous subject"))
     }


### PR DESCRIPTION
Key command 'p' for previous subject interferes with hardware keyboard answer input. This change adds a command-key modifier to prevent that.