### PR TITLE
Disable kanji suggestions if auto-switch is on

### DIFF
--- a/ios/AnswerTextField.swift
+++ b/ios/AnswerTextField.swift
@@ -30,6 +30,7 @@ class AnswerTextField: UITextField {
   public var useJapaneseKeyboard: Bool = false {
     didSet {
       if oldValue != useJapaneseKeyboard {
+        self.autocorrectionType = useJapaneseKeyboard ? .no : .yes
         if self.isFirstResponder {
           // Reload the keyboard if we just changed its language.
           self.resignFirstResponder()

--- a/ios/SettingsViewController.swift
+++ b/ios/SettingsViewController.swift
@@ -173,7 +173,7 @@ class SettingsViewController: UITableViewController {
 
     let keyboardSwitchItem = TKMSwitchModelItem(style: .subtitle,
                                                 title: "Switch to Japanese keyboard",
-                                                subtitle: "Automatically switch to a Japanese keyboard to type reading answers",
+                                                subtitle: "Automatically switch to a Japanese keyboard to type reading answers, and hides kanji suggestions",
                                                 on: Settings.autoSwitchKeyboard,
                                                 target: self,
                                                 action: #selector(autoSwitchKeyboardSwitchChanged(_:)))


### PR DESCRIPTION
Just a minor tweak that seems useful for using Japanese keyboards...

**Edit:** Upon testing, it's not working, so I'm marking as draft. Perhaps [this SO question](https://stackoverflow.com/q/67022738) will shed some light later as to how to fix this...