### PR TITLE
Tsurukame Widget Extension

### DIFF
--- a/ios/AppGroup.swift
+++ b/ios/AppGroup.swift
@@ -1,0 +1,210 @@
+// Copyright 2021 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+#if canImport(WidgetKit)
+  import WidgetKit
+#endif
+
+// MARK: - CodedWidgetData
+
+public struct CodedWidgetData: Codable {
+  public var lessons: Int = -2
+  public var reviews: Int = -2
+  public var reviewForecast: [Int] = []
+  public var date = Date()
+
+  public var isDefault: Bool { lessons == -2 && reviews == -2 }
+  public var isSample: Bool { lessons == -1 && reviews == -1 }
+}
+
+extension CodedWidgetData {
+  init(sampleData: Bool) {
+    guard sampleData else {
+      self.init()
+      return
+    }
+    self.init(lessons: -1, reviews: -1, reviewForecast: [], date: Date())
+  }
+}
+
+// MARK: - ReviewCounts
+
+public struct ReviewCounts: Codable, Hashable, Identifiable {
+  public var id = UUID()
+  public var date: Date
+  public var total: Int
+  public var new: Int
+
+  static func projectedReviews(from data: CodedWidgetData) -> [ReviewCounts] {
+    var date = data.date.hourTruncated!, total = data.reviews, forecast: [ReviewCounts] = []
+    for newReviews in data.reviewForecast {
+      date += 3600
+      total += newReviews
+      forecast.append(ReviewCounts(date: date, total: total, new: newReviews))
+    }
+    return forecast
+  }
+}
+
+// MARK: - ExpandedWidgetData
+
+public struct ExpandedWidgetData: Codable {
+  public var date: Date
+  public var lessons: Int
+  public var reviewForecast: [ReviewCounts]
+
+  public var reviews: Int { (reviewForecast.first?.total ?? 0) - (reviewForecast.first?.new ?? 0) }
+
+  public func projected(for date: Date) -> ExpandedWidgetData {
+    var projectedCounts = reviewForecast
+    while projectedCounts.count > 0 {
+      guard projectedCounts.first!.date <= date else { break }
+      projectedCounts.removeFirst()
+    }
+    return ExpandedWidgetData(date: date, lessons: lessons, reviewForecast: projectedCounts)
+  }
+
+  public func todayForecast(for date: Date) -> [ReviewCounts] {
+    var todayForecast: [ReviewCounts] = []
+    for forecastEntry in reviewForecast {
+      if forecastEntry.date.dateString == date.dateString {
+        todayForecast.append(forecastEntry)
+      }
+    }
+    return todayForecast
+  }
+
+  public func weekDailyReviewForecast(after date: Date) -> [DailyReviews] {
+    var workingDate = "", hasReachedTargetDate = false, dailyReviews: [DailyReviews] = []
+    for counts in reviewForecast {
+      guard counts.date.dateString != date.dateString else {
+        hasReachedTargetDate = true
+        continue
+      }
+      guard hasReachedTargetDate else { continue }
+      if counts.date.dateString != workingDate {
+        dailyReviews.append(DailyReviews(counts: [counts]))
+        workingDate = counts.date.dateString
+        continue
+      }
+      dailyReviews[dailyReviews.count - 1].append(counts)
+    }
+    return Array(dailyReviews[0 ... 6])
+  }
+}
+
+// MARK: - DailyReviews
+
+public struct DailyReviews: Codable, Hashable, Identifiable {
+  public static let hours = [0, 3, 7, 11, 15, 19, 23]
+
+  public var id = UUID()
+  private var counts: [ReviewCounts] = []
+
+  public var filteredCounts: [ReviewCounts] {
+    var filtered: [ReviewCounts] = [], new = 0
+    for reviewCount in counts {
+      new += reviewCount.new
+      print(reviewCount.date.hour)
+      if DailyReviews.hours.contains(reviewCount.date.hour) {
+        filtered.append(ReviewCounts(date: reviewCount.date, total: reviewCount.total, new: new))
+        new = 0
+      }
+    }
+    print(filtered)
+    return filtered
+  }
+
+  public var dayOfWeek: String { counts.first?.date.dayOfWeek ?? "" }
+  public var total: Int { counts.last?.total ?? 0 }
+  public var initialTotal: Int { (counts.first?.total ?? 0) - (counts.first?.new ?? 0) }
+  public var new: Int { total - initialTotal }
+
+  public mutating func append(_ counts: ReviewCounts) { self.counts.append(counts) }
+
+  init(counts: [ReviewCounts]) { self.counts = counts }
+}
+
+public extension Date {
+  var hour: Int {
+    Calendar.current.dateComponents([.hour], from: self).hour!
+  }
+
+  var hourTruncated: Date? {
+    Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: self)
+  }
+
+  var dayOfWeek: String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "EEE"
+    return dateFormatter.string(from: self).capitalized
+  }
+
+  var timeString: String {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .none
+    formatter.timeStyle = .short
+    return formatter.string(from: self)
+  }
+
+  var dateString: String {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .full
+    formatter.timeStyle = .none
+    return formatter.string(from: self)
+  }
+}
+
+// MARK: - Data access
+
+public enum AppGroup {
+  static let bundle = (Bundle.main.infoDictionary!["CFBundleIdentifier"] as! String)
+    .split(separator: ".")[0 ... 2].joined(separator: ".")
+  static let wanikani = "group.\(bundle)"
+  static let widget = "\(bundle).widget"
+
+  static let containerURL =
+    FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: wanikani)!
+
+  static let dataURL = containerURL.appendingPathComponent("WidgetData.plist")
+
+  @available(iOS 14.0, iOSApplicationExtension 14.0, macCatalyst 14.0, *)
+  public static func reloadTimeline() {
+    #if canImport(WidgetKit) && (arch(arm64) || arch(i386) || arch(x86_64))
+      WidgetCenter.shared.reloadAllTimelines()
+      print("Reloaded timeline!")
+    #endif
+  }
+
+  public static func readGroupData() -> ExpandedWidgetData {
+    var d: CodedWidgetData
+    if let data = try? Data(contentsOf: AppGroup.dataURL),
+       let decodedData = try? PropertyListDecoder().decode(CodedWidgetData.self, from: data) {
+      d = decodedData
+    } else {
+      d = CodedWidgetData(sampleData: true)
+    }
+    return ExpandedWidgetData(date: d.date, lessons: d.lessons,
+                              reviewForecast: ReviewCounts.projectedReviews(from: d))
+  }
+
+  public static func writeGroupData(_ lessons: Int, _ reviews: Int, _ reviewForecast: [Int]) {
+    let data = CodedWidgetData(lessons: lessons, reviews: reviews, reviewForecast: reviewForecast,
+                               date: Date().hourTruncated!)
+    let encoder = PropertyListEncoder()
+    try! encoder.encode(data).write(to: AppGroup.dataURL)
+    if #available(iOS 14.0, iOSApplicationExtension 14.0, macCatalyst 14.0, *) { reloadTimeline() }
+  }
+}

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -167,6 +167,7 @@ class MainViewController: UITableViewController, LoginViewControllerDelegate,
     let currentLevelAssignments = services.localCachingClient.getAssignmentsAtUsersCurrentLevel()
 
     let model = TKMMutableTableModel(tableView: tableView)
+    AppGroup.writeGroupData(lessons, reviews, upcomingReviews)
 
     if !user.hasVacationStartedAt {
       model.addSection("Currently available")

--- a/ios/Resources/Tsurukame.entitlements
+++ b/ios/Resources/Tsurukame.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.davidsansome.wanikani</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		482D7C0F261CC29900104F69 /* ApprenticeLimitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482D7C0E261CC29900104F69 /* ApprenticeLimitViewController.swift */; };
 		483EBFDC261DD7190043C804 /* FontScreenshotterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4874562D261DD28E00F33AA3 /* FontScreenshotterUITests.swift */; };
 		48CF714823EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 48CF714623EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m */; };
+		48D8B59D2526A17B000470EE /* AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D8B48C252660B9000470EE /* AppGroup.swift */; };
 		48F4B1DC268CB9850033860E /* UpcomingReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F4B1DB268CB9850033860E /* UpcomingReviewsViewController.swift */; };
 		5C82B2908507339A293B0E59 /* Pods_FontScreenshotter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F33812F134DC80E5D981C40E /* Pods_FontScreenshotter.framework */; };
 		630ADB6F21F8256E00BC9801 /* TKMCheckmarkModelItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 630ADB6E21F8256E00BC9801 /* TKMCheckmarkModelItem.m */; };
@@ -225,6 +226,7 @@
 		4874562E261DD28E00F33AA3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		489894D423670CB000A20AF8 /* Tsurukame.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tsurukame.entitlements; sourceTree = "<group>"; };
 		48CF714623EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TKMReviewBatchSizeViewController.m; sourceTree = "<group>"; };
+		48D8B48C252660B9000470EE /* AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroup.swift; sourceTree = "<group>"; };
 		48F4B1DB268CB9850033860E /* UpcomingReviewsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpcomingReviewsViewController.swift; sourceTree = "<group>"; };
 		4B8236EC341CF1BA18D16857 /* Pods-Tsurukame-Tsurukame Complication Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tsurukame-Tsurukame Complication Extension.release.xcconfig"; path = "Target Support Files/Pods-Tsurukame-Tsurukame Complication Extension/Pods-Tsurukame-Tsurukame Complication Extension.release.xcconfig"; sourceTree = "<group>"; };
 		630ADB6D21F8256E00BC9801 /* TKMCheckmarkModelItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TKMCheckmarkModelItem.h; sourceTree = "<group>"; };
@@ -494,6 +496,7 @@
 				631CAD62234AD5FC008CEA73 /* AnswerChecker.swift */,
 				C904455C2395DBAE001BC48B /* AnswerTextField.swift */,
 				638A5C4D25A471F9001A7AEE /* AppDelegate.swift */,
+				48D8B48C252660B9000470EE /* AppGroup.swift */,
 				6335B46323CF0C820071671E /* AppStoreScreenshots */,
 				6335B46223CF0C820071671E /* AppStoreScreenshots.xctest */,
 				482D7C0E261CC29900104F69 /* ApprenticeLimitViewController.swift */,
@@ -1213,6 +1216,7 @@
 				63F7F51F23D3F335006A31FB /* ReadingModelItem.swift in Sources */,
 				633DE9322094D22800AC25F4 /* ReviewOrderViewController.m in Sources */,
 				633AFAE62352B6F2004F732F /* VocabularyHighlighter.swift in Sources */,
+				48D8B59D2526A17B000470EE /* AppGroup.swift in Sources */,
 				631CAD63234AD5FC008CEA73 /* AnswerChecker.swift in Sources */,
 				63C74C6825C96088004F6C99 /* SubjectChip.swift in Sources */,
 				482D7C0F261CC29900104F69 /* ApprenticeLimitViewController.swift in Sources */,
@@ -1749,7 +1753,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.davidsansome.wk.Tests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.davidsansome.wanikani.Tests;
 				PRODUCT_MODULE_NAME = Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tsurukame-Bridging-Header.h";
@@ -1777,7 +1781,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.davidsansome.wk.Tests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.davidsansome.wanikani.Tests;
 				PRODUCT_MODULE_NAME = Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tsurukame-Bridging-Header.h";

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -12,7 +12,13 @@
 		481B2FED23C55AAF0041EF1F /* CurrentLevelReviewTimeItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481B2FEC23C55AAF0041EF1F /* CurrentLevelReviewTimeItem.swift */; };
 		4820306724D849E100B40FDD /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633632EE201F3490006D582B /* Settings.swift */; };
 		482D7C0F261CC29900104F69 /* ApprenticeLimitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482D7C0E261CC29900104F69 /* ApprenticeLimitViewController.swift */; };
+		483070C325276D3400150CF8 /* AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D8B48C252660B9000470EE /* AppGroup.swift */; };
 		483EBFDC261DD7190043C804 /* FontScreenshotterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4874562D261DD28E00F33AA3 /* FontScreenshotterUITests.swift */; };
+		4868F4BF25276CE400B49700 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4801CC8725276A98000EA03D /* WidgetKit.framework */; platformFilter = ios; };
+		4868F4C025276CE400B49700 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4801CC8925276A98000EA03D /* SwiftUI.framework */; };
+		4868F4C325276CE400B49700 /* WidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4868F4C225276CE400B49700 /* WidgetExtension.swift */; };
+		4868F4C625276CE500B49700 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4868F4C525276CE500B49700 /* Assets.xcassets */; };
+		4868F4CC25276CE500B49700 /* WidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4868F4BE25276CE400B49700 /* WidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		48CF714823EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 48CF714623EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m */; };
 		48D8B59D2526A17B000470EE /* AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D8B48C252660B9000470EE /* AppGroup.swift */; };
 		48F4B1DC268CB9850033860E /* UpcomingReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F4B1DB268CB9850033860E /* UpcomingReviewsViewController.swift */; };
@@ -148,6 +154,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4868F4CA25276CE500B49700 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 630FD60B1FC45BDF00D21C1F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4868F4BD25276CE400B49700;
+			remoteInfo = WidgetExtensionExtension;
+		};
 		6335B46723CF0C820071671E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 630FD60B1FC45BDF00D21C1F /* Project object */;
@@ -186,6 +199,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		48A21BFE25254E53007B2E2B /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				4868F4CC25276CE500B49700 /* WidgetExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C90846C9237F1C790068A272 /* Embed Watch Content */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -219,12 +243,21 @@
 		301BAAC2C21E4A99238D1E80 /* Pods-FontScreenshotter-FontScreenshotterUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FontScreenshotter-FontScreenshotterUITests.release.xcconfig"; path = "Target Support Files/Pods-FontScreenshotter-FontScreenshotterUITests/Pods-FontScreenshotter-FontScreenshotterUITests.release.xcconfig"; sourceTree = "<group>"; };
 		34E86AD95515CD815B3086D0 /* Pods-Tsurukame.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tsurukame.debug.xcconfig"; path = "Target Support Files/Pods-Tsurukame/Pods-Tsurukame.debug.xcconfig"; sourceTree = "<group>"; };
 		404461BC39B4A19B128F9E69 /* Pods_FontScreenshotter_FontScreenshotterUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FontScreenshotter_FontScreenshotterUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4801CC8725276A98000EA03D /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		4801CC8925276A98000EA03D /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		481B2FEC23C55AAF0041EF1F /* CurrentLevelReviewTimeItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrentLevelReviewTimeItem.swift; sourceTree = "<group>"; };
 		4826740B23ECE46900F704E4 /* TKMReviewBatchSizeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TKMReviewBatchSizeViewController.h; sourceTree = "<group>"; };
 		482D7C0E261CC29900104F69 /* ApprenticeLimitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApprenticeLimitViewController.swift; sourceTree = "<group>"; };
+		4868F4BE25276CE400B49700 /* WidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		4868F4C225276CE400B49700 /* WidgetExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetExtension.swift; sourceTree = "<group>"; };
+		4868F4C525276CE500B49700 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4868F4C725276CE500B49700 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4868F4CD25276CE500B49700 /* WidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WidgetExtension.entitlements; sourceTree = "<group>"; };
 		4874562D261DD28E00F33AA3 /* FontScreenshotterUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontScreenshotterUITests.swift; sourceTree = "<group>"; };
 		4874562E261DD28E00F33AA3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		489894D423670CB000A20AF8 /* Tsurukame.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tsurukame.entitlements; sourceTree = "<group>"; };
+		48A21BF025254E53007B2E2B /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
+		48A21BF225254E53007B2E2B /* UserNotificationsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotificationsUI.framework; path = System/Library/Frameworks/UserNotificationsUI.framework; sourceTree = SDKROOT; };
 		48CF714623EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TKMReviewBatchSizeViewController.m; sourceTree = "<group>"; };
 		48D8B48C252660B9000470EE /* AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroup.swift; sourceTree = "<group>"; };
 		48F4B1DB268CB9850033860E /* UpcomingReviewsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpcomingReviewsViewController.swift; sourceTree = "<group>"; };
@@ -384,6 +417,16 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4868F4BB25276CE400B49700 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				48D166A826A8824B006AD969 /* NotificationCenter.framework in Frameworks */,
+				4868F4C025276CE400B49700 /* SwiftUI.framework in Frameworks */,
+				4868F4BF25276CE400B49700 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		630FD6101FC45BDF00D21C1F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -479,6 +522,17 @@
 				63D1026823D7ED3200838F7C /* UIWindow+InterfaceStyle.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		4868F4C125276CE400B49700 /* WidgetExtension */ = {
+			isa = PBXGroup;
+			children = (
+				4868F4CD25276CE500B49700 /* WidgetExtension.entitlements */,
+				4868F4C525276CE500B49700 /* Assets.xcassets */,
+				4868F4C725276CE500B49700 /* Info.plist */,
+				4868F4C225276CE400B49700 /* WidgetExtension.swift */,
+			);
+			path = WidgetExtension;
 			sourceTree = "<group>";
 		};
 		4874562C261DD28E00F33AA3 /* FontScreenshotterUITests */ = {
@@ -585,6 +639,8 @@
 				633AFAE52352B6F2004F732F /* VocabularyHighlighter.swift */,
 				63CAB4F72605F9AF0057E1C2 /* WaniKaniAPI */,
 				C92AB96E237F280300F79904 /* WatchHelper.swift */,
+				4868F4C125276CE400B49700 /* WidgetExtension */,
+				4868F4BE25276CE400B49700 /* WidgetExtension.appex */,
 			);
 			sourceTree = "<group>";
 		};
@@ -649,6 +705,7 @@
 		63CAAB0F1FD7FAC500E09DA1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				48D166A726A8824A006AD969 /* NotificationCenter.framework */,
 				6364A10A242DFB6F000ABF32 /* Intents.framework */,
 				6356E7821FDFF0E3009CE7C1 /* WebKit.framework */,
 				63CAAB101FD7FAC600E09DA1 /* SystemConfiguration.framework */,
@@ -656,6 +713,10 @@
 				68B19C946E2F2284DA18EC3F /* Pods_Tsurukame__App_Store_screenshots_.framework */,
 				1BBBD142815F6A55FA9D2C21 /* libPods-Tsurukame Complication Extension.a */,
 				404461BC39B4A19B128F9E69 /* Pods_FontScreenshotter_FontScreenshotterUITests.framework */,
+				48A21BF025254E53007B2E2B /* UserNotifications.framework */,
+				48A21BF225254E53007B2E2B /* UserNotificationsUI.framework */,
+				4801CC8725276A98000EA03D /* WidgetKit.framework */,
+				4801CC8925276A98000EA03D /* SwiftUI.framework */,
 				10E5709643045C62AD6AC427 /* Pods_Tests.framework */,
 				FC80AAF9736A570E3C4CC09E /* Pods_Tsurukame.framework */,
 			);
@@ -722,6 +783,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4868F4BD25276CE400B49700 /* WidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4868F4CE25276CE500B49700 /* Build configuration list for PBXNativeTarget "WidgetExtension" */;
+			buildPhases = (
+				4868F4BA25276CE400B49700 /* Sources */,
+				4868F4BB25276CE400B49700 /* Frameworks */,
+				4868F4BC25276CE400B49700 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WidgetExtension;
+			productName = WidgetExtensionExtension;
+			productReference = 4868F4BE25276CE400B49700 /* WidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		630FD6121FC45BDF00D21C1F /* Tsurukame */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 630FD6291FC45BDF00D21C1F /* Build configuration list for PBXNativeTarget "Tsurukame" */;
@@ -732,6 +810,7 @@
 				630FD6101FC45BDF00D21C1F /* Frameworks */,
 				630FD6111FC45BDF00D21C1F /* Resources */,
 				C90846C9237F1C790068A272 /* Embed Watch Content */,
+				48A21BFE25254E53007B2E2B /* Embed App Extensions */,
 				0C9C13E732A68C21AE8F0AA3 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
@@ -739,6 +818,7 @@
 			dependencies = (
 				63EF56FD26060BE50038551A /* PBXTargetDependency */,
 				C90846C7237F1C790068A272 /* PBXTargetDependency */,
+				4868F4CB25276CE500B49700 /* PBXTargetDependency */,
 			);
 			name = Tsurukame;
 			packageProductDependencies = (
@@ -879,6 +959,9 @@
 				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = "David Sansome";
 				TargetAttributes = {
+					4868F4BD25276CE400B49700 = {
+						CreatedOnToolsVersion = 12.0.1;
+					};
 					630FD6121FC45BDF00D21C1F = {
 						CreatedOnToolsVersion = 9.1;
 						LastSwiftMigration = 0920;
@@ -941,11 +1024,20 @@
 				C90846AB237F1C770068A272 /* Tsurukame Complication */,
 				C90846B7237F1C790068A272 /* Tsurukame Complication Extension */,
 				6335B46123CF0C820071671E /* AppStoreScreenshots */,
+				4868F4BD25276CE400B49700 /* WidgetExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4868F4BC25276CE400B49700 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4868F4C625276CE500B49700 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		630FD6111FC45BDF00D21C1F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1193,6 +1285,15 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4868F4BA25276CE400B49700 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4868F4C325276CE400B49700 /* WidgetExtension.swift in Sources */,
+				483070C325276D3400150CF8 /* AppGroup.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		630FD60F1FC45BDF00D21C1F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1345,6 +1446,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4868F4CB25276CE500B49700 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4868F4BD25276CE400B49700 /* WidgetExtension */;
+			targetProxy = 4868F4CA25276CE500B49700 /* PBXContainerItemProxy */;
+		};
 		6335B46823CF0C820071671E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 630FD6121FC45BDF00D21C1F /* Tsurukame */;
@@ -1401,6 +1507,75 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		4868F4CF25276CE500B49700 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_ENTITLEMENTS = WidgetExtension/WidgetExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 810;
+				DEVELOPMENT_TEAM = 7B2GP77Y4A;
+				INFOPLIST_FILE = WidgetExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.23;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.davidsansome.wanikani.widgetextension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4868F4D025276CE500B49700 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CODE_SIGN_ENTITLEMENTS = WidgetExtension/WidgetExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 810;
+				DEVELOPMENT_TEAM = 7B2GP77Y4A;
+				INFOPLIST_FILE = WidgetExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.23;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.davidsansome.wanikani.widgetextension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		630FD6271FC45BDF00D21C1F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1440,6 +1615,7 @@
 				DEFINES_MODULE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1503,6 +1679,7 @@
 				DEFINES_MODULE = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1526,6 +1703,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 34E86AD95515CD815B3086D0 /* Pods-Tsurukame.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Resources/Tsurukame.entitlements;
@@ -1560,6 +1738,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 21894D9E0883B0107075DD6F /* Pods-Tsurukame.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Resources/Tsurukame.entitlements;
@@ -1912,6 +2091,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4868F4CE25276CE500B49700 /* Build configuration list for PBXNativeTarget "WidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4868F4CF25276CE500B49700 /* Debug */,
+				4868F4D025276CE500B49700 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		630FD60E1FC45BDF00D21C1F /* Build configuration list for PBXProject "Tsurukame" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ios/WidgetExtension/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/WidgetExtension/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/WidgetExtension/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/WidgetExtension/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/WidgetExtension/Assets.xcassets/Contents.json
+++ b/ios/WidgetExtension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/WidgetExtension/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/ios/WidgetExtension/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/WidgetExtension/Info.plist
+++ b/ios/WidgetExtension/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Tsurukame Widget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/WidgetExtension/WidgetExtension.entitlements
+++ b/ios/WidgetExtension/WidgetExtension.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.davidsansome.wanikani</string>
+	</array>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/WidgetExtension/WidgetExtension.swift
+++ b/ios/WidgetExtension/WidgetExtension.swift
@@ -1,0 +1,188 @@
+// Copyright 2021 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Intents
+import SwiftUI
+import WidgetKit
+
+private extension Font {
+  static func getFont(size: CGFloat, weight: Font.Weight, monospace: Bool = true) -> Font {
+    if monospace {
+      return Font.system(size: size, weight: weight, design: .default).monospacedDigit()
+    } else {
+      return Font.system(size: size, weight: weight, design: .default)
+    }
+  }
+}
+
+extension View {
+  func equalSpacedFrame() -> some View {
+    frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
+  }
+}
+
+struct WidgetProvider: TimelineProvider {
+  func data(_ date: Date) -> ExpandedWidgetData {
+    AppGroup.readGroupData().projected(for: date)
+  }
+
+  func placeholder(in _: Context) -> WidgetEntry {
+    WidgetEntry(date: Date(), data: data(Date()))
+  }
+
+  func getSnapshot(in _: Context, completion: @escaping (WidgetEntry) -> Void) {
+    let entry = WidgetEntry(date: Date(), data: data(Date()))
+    completion(entry)
+  }
+
+  func getTimeline(in _: Context, completion: @escaping (Timeline<Entry>) -> Void) {
+    var entries: [WidgetEntry] = []
+
+    // Generate a timeline consisting of now and 24 entries an hour apart.
+    let currentDate = Date()
+    entries.append(WidgetEntry(date: currentDate, data: data(currentDate)))
+    let zeroOffsetDate = currentDate.hourTruncated!
+    for hourOffset in 1 ... 24 {
+      let entryDate = zeroOffsetDate + Double(3600 * hourOffset)
+      let entry = WidgetEntry(date: entryDate, data: data(entryDate))
+      entries.append(entry)
+    }
+
+    let timeline = Timeline(entries: entries, policy: .atEnd)
+    completion(timeline)
+  }
+}
+
+struct WidgetEntry: TimelineEntry {
+  let date: Date
+  let data: ExpandedWidgetData
+}
+
+struct WidgetView: View {
+  var entry: WidgetProvider.Entry
+  @Environment(\.widgetFamily) private var widgetFamily
+
+  init(entry: WidgetProvider.Entry) {
+    self.entry = entry
+  }
+
+  private func gridLayout(columns: Int, spacing: CGFloat = 30,
+                          _ bonusFirst: CGFloat = 0,
+                          _ bonusLast2: CGFloat = 0,
+                          _ bonusLast: CGFloat = 0) -> [GridItem] {
+    var items = Array(repeating: GridItem(.fixed(spacing)), count: columns)
+    items[0].size = .fixed(spacing + bonusFirst)
+    if columns > 2 {
+      items[items.count - 2].size = .fixed(spacing + bonusLast2)
+      items[items.count - 1].size = .fixed(spacing + bonusLast)
+    }
+    return items
+  }
+
+  var lessonReviewSmallBox: some View {
+    VStack {
+      HStack(alignment: .center, spacing: 50.0) {
+        let largeTitle = Font.getFont(size: 30.0, weight: .bold)
+        Text("\(entry.data.lessons)").font(largeTitle)
+        Text("\(entry.data.reviews)").font(largeTitle)
+      }
+      HStack(alignment: .center, spacing: 30.0) {
+        Text("Lessons").font(.subheadline)
+        Text("Reviews").font(.subheadline)
+      }
+      Text(entry.date.timeString)
+    }.equalSpacedFrame()
+  }
+
+  var currentDayForecastSmallBox: some View {
+    LazyVGrid(columns: gridLayout(columns: 3, spacing: 28, 25), alignment: .trailing) {
+      ForEach(entry.data.todayForecast(for: entry.date)) { forecastEntry in
+        if forecastEntry.new != 0 {
+          let forecastSmFont = Font.getFont(size: 11, weight: .light)
+          Text(forecastEntry.date.timeString).font(forecastSmFont)
+          Text("+\(forecastEntry.new)").font(forecastSmFont)
+          Text("\(forecastEntry.total) ").font(forecastSmFont)
+        }
+      }
+    }.equalSpacedFrame()
+  }
+
+  var weekForecastMediumBox: some View {
+    LazyVGrid(columns: gridLayout(columns: 10, spacing: 25, -4, 6), alignment: .trailing) {
+      let forecastMedFont = Font.getFont(size: 9.5, weight: .light)
+      ForEach([""] + DailyReviews.hours.map { "\($0)" } + ["New", "All"],
+              id: \.self) { header in
+        Text(header).font(forecastMedFont)
+      }
+      ForEach(entry.data.weekDailyReviewForecast(after: entry.date)) { dayForecast in
+        Text("\(dayForecast.dayOfWeek)").font(forecastMedFont)
+        ForEach(dayForecast.filteredCounts) { futureReviews in
+          Text("+\(futureReviews.new)").font(forecastMedFont)
+        }
+        Text("+\(String(dayForecast.new))").font(forecastMedFont)
+        Text("\(String(dayForecast.total)) ").font(forecastMedFont)
+      }
+    }.equalSpacedFrame()
+  }
+
+  private var currentDayForecastDefault: some View {
+    Text("No additional reviews today! \u{1F389}").equalSpacedFrame()
+  }
+
+  private var weekForecastDefault: some View {
+    Text("No upcoming reviews this week! \u{1F389}").equalSpacedFrame()
+  }
+
+  var body: some View {
+    if widgetFamily == .systemSmall {
+      lessonReviewSmallBox
+    } else if widgetFamily == .systemMedium {
+      HStack {
+        lessonReviewSmallBox
+        Divider()
+        if entry.data.reviewForecast.count > 0 { currentDayForecastSmallBox }
+        else { currentDayForecastDefault }
+      }
+    } else {
+      VStack {
+        HStack {
+          lessonReviewSmallBox
+          if entry.data.reviewForecast.count > 0 { currentDayForecastSmallBox }
+          else { currentDayForecastDefault }
+        }
+        Divider()
+        if entry.data.weekDailyReviewForecast(after: entry.date).count > 0 {
+          weekForecastMediumBox
+        } else { weekForecastDefault }
+      }
+    }
+  }
+}
+
+@main struct WidgetExtension: Widget {
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: AppGroup.widget,
+                        provider: WidgetProvider()) { entry in WidgetView(entry: entry) }
+      .configurationDisplayName("Tsurukame Widget")
+      .description("Displays lessons, reviews, and forecast!")
+      .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+  }
+}
+
+struct WidgetPreviews: PreviewProvider {
+  static var previews: some View {
+    WidgetView(entry: WidgetEntry(date: Date(), data: WidgetProvider().data(Date())))
+      .previewContext(WidgetPreviewContext(family: .systemLarge))
+  }
+}


### PR DESCRIPTION
This pull request fixes #376 by adding a WidgetKit widget, which supports by necessity only macOS 11+ and iOS 14+.

Adding the prior Today View iOS widget is beyond the scope of this PR, since it's already large enough.

As previously discussed in #270, adding the App Groups capability was in fact required to implement this. However, instead of moving the existing caching client, this PR proposes to simply save/load the data to/from a file.