### PR TITLE
Make review label number of lines 2

### DIFF
--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -350,7 +350,7 @@
                                     <constraint firstAttribute="trailing" secondItem="kc6-Lm-8sK" secondAttribute="trailing" constant="8" id="hnc-JP-Evv"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="40" translatesAutoresizingMaskIntoConstraints="NO" id="Nab-RQ-m49">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="40" translatesAutoresizingMaskIntoConstraints="NO" id="Nab-RQ-m49">
                                 <rect key="frame" x="0.0" y="20" width="375" height="543"/>
                                 <fontDescription key="fontDescription" name=".SFNSDisplay" family=".SF NS Display" pointSize="60"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
Quick fix for issue #313. Made number of lines 2 instead of one. Maybe it should be 0? 

I used Xcode 12.0.1 so that might have caused the extra storyboard changes

Screenshots on 11 pro with 125% font size
| Before        | After           |
| ----------- |------------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-03 at 17 25 17](https://user-images.githubusercontent.com/15106299/94996691-0ca45500-059e-11eb-928b-c90ab14043e5.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-10-03 at 17 24 45](https://user-images.githubusercontent.com/15106299/94996697-129a3600-059e-11eb-85e9-2d9def7698e6.png) |