### PR TITLE
Emergency formatting

### DIFF
--- a/ios/AnswerChecker.swift
+++ b/ios/AnswerChecker.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/AppStoreScreenshots/Screenshotter.swift
+++ b/ios/AppStoreScreenshots/Screenshotter.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/Audio.swift
+++ b/ios/Audio.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/CGContext+Blur.swift
+++ b/ios/CGContext+Blur.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/ComplicationExtension/ComplicationController.swift
+++ b/ios/ComplicationExtension/ComplicationController.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/ComplicationExtension/DataManager.swift
+++ b/ios/ComplicationExtension/DataManager.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/ComplicationExtension/ExtensionDelegate.swift
+++ b/ios/ComplicationExtension/ExtensionDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/ComplicationExtension/SettingsController.swift
+++ b/ios/ComplicationExtension/SettingsController.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/CurrentLevelChartItem.swift
+++ b/ios/CurrentLevelChartItem.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/CurrentLevelReviewTimeItem.swift
+++ b/ios/CurrentLevelReviewTimeItem.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/DataLoader.swift
+++ b/ios/DataLoader.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/Extensions/UIWindow+InterfaceStyle.swift
+++ b/ios/Extensions/UIWindow+InterfaceStyle.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/InterfaceStyleViewController.swift
+++ b/ios/InterfaceStyleViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/MainHeaderView.swift
+++ b/ios/MainHeaderView.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/OfflineAudioViewController.swift
+++ b/ios/OfflineAudioViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/SRSStageCategoryItem.swift
+++ b/ios/SRSStageCategoryItem.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/SettingsViewController.m
+++ b/ios/SettingsViewController.m
@@ -205,7 +205,7 @@ typedef void (^NotificationPermissionHandler)(BOOL granted);
                                 on:Settings.allowSkippingReviews
                             target:self
                             action:@selector(allowSkippingReviewsSwitchChanged:)]];
-  
+
   TKMSwitchModelItem *minimizeReviewPenaltyItem =
       [[TKMSwitchModelItem alloc] initWithStyle:UITableViewCellStyleSubtitle
                                           title:@"Minimize review penalty"

--- a/ios/SiriShortcutHelper.swift
+++ b/ios/SiriShortcutHelper.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/String+MD5.swift
+++ b/ios/String+MD5.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/Style.swift
+++ b/ios/Style.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/Tables/AttributedModelItem.swift
+++ b/ios/Tables/AttributedModelItem.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/Tables/ContextSentenceModelItem.swift
+++ b/ios/Tables/ContextSentenceModelItem.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/Tables/ReadingModelItem.swift
+++ b/ios/Tables/ReadingModelItem.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/UpcomingReviewsChartItem.swift
+++ b/ios/UpcomingReviewsChartItem.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/VocabularyHighlighter.swift
+++ b/ios/VocabularyHighlighter.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ios/WatchHelper.swift
+++ b/ios/WatchHelper.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 David Sansome
+// Copyright 2021 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This commit changes the 2020 to 2021 in the header on Swift files.

(In addition, it revives the TestFlight beta, which has expired after 90 days of no commits.)