### PR TITLE
Add option to hide stats section

### DIFF
--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -158,6 +158,7 @@ private func getArchiveData<T: Codable>(_ defaultValue: T, key: String) -> T {
     .vocabulary,
   ], "lessonOrder") static var lessonOrder: [TKMSubject.TypeEnum]
   @Setting(5, #keyPath(lessonBatchSize)) static var lessonBatchSize: Int
+  @Setting(true, #keyPath(showStatsSection)) static var showStatsSection: Bool
 
   @EnumSetting(ReviewOrder.random, #keyPath(reviewOrder)) static var reviewOrder: ReviewOrder
   @Setting(5, #keyPath(reviewBatchSize)) static var reviewBatchSize: Int
@@ -169,7 +170,7 @@ private func getArchiveData<T: Codable>(_ defaultValue: T, key: String) -> T {
   @Setting(false, #keyPath(exactMatch)) static var exactMatch: Bool
   @Setting(true, #keyPath(enableCheats)) static var enableCheats: Bool
   @Setting(true, #keyPath(showOldMnemonic)) static var showOldMnemonic: Bool
-  @Setting(true, #keyPath(useKatakanaForOnyomi)) static var useKatakanaForOnyomi: Bool
+  @Setting(false, #keyPath(useKatakanaForOnyomi)) static var useKatakanaForOnyomi: Bool
   @Setting(false, #keyPath(showSRSLevelIndicator)) static var showSRSLevelIndicator: Bool
   @Setting(false, #keyPath(showAllReadings)) static var showAllReadings: Bool
   @Setting(false, #keyPath(autoSwitchKeyboard)) static var autoSwitchKeyboard: Bool

--- a/ios/SettingsViewController.swift
+++ b/ios/SettingsViewController.swift
@@ -87,6 +87,12 @@ class SettingsViewController: UITableViewController {
                                 accessoryType: .disclosureIndicator,
                                 target: self,
                                 action: #selector(didTapLessonBatchSize(_:))))
+    model.add(TKMSwitchModelItem(style: .subtitle,
+                                 title: "Show stats section",
+                                 subtitle: "Show view with level, SRS stage, and more",
+                                 on: Settings.showStatsSection,
+                                 target: self,
+                                 action: #selector(showStatsSectionChanged(_:))))
 
     model.addSection("Reviews")
     model.add(TKMBasicModelItem(style: .value1,
@@ -290,6 +296,10 @@ class SettingsViewController: UITableViewController {
 
   @objc private func prioritizeCurrentLevelChanged(_ switchView: UISwitch) {
     Settings.prioritizeCurrentLevel = switchView.isOn
+  }
+  
+  @objc private func showStatsSectionChanged(_ switchView: UISwitch) {
+    Settings.showStatsSection = switchView.isOn
   }
 
   @objc private func groupMeaningReadingSwitchChanged(_ switchView: UISwitch) {

--- a/ios/SettingsViewController.swift
+++ b/ios/SettingsViewController.swift
@@ -89,7 +89,7 @@ class SettingsViewController: UITableViewController {
                                 action: #selector(didTapLessonBatchSize(_:))))
     model.add(TKMSwitchModelItem(style: .subtitle,
                                  title: "Show stats section",
-                                 subtitle: "Show view with level, SRS stage, and more",
+                                 subtitle: "Show section with level, SRS stage, and more",
                                  on: Settings.showStatsSection,
                                  target: self,
                                  action: #selector(showStatsSectionChanged(_:))))

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -347,7 +347,7 @@ class SubjectDetailsView: UITableView, SubjectChipDelegate {
     }
 
     // Your progress, SRS level, next review, first started, reached guru
-    if let subjectAssignment = assignment {
+    if let subjectAssignment = assignment, Settings.showStatsSection {
       model.addSection("Stats")
       model.add(TKMBasicModelItem(style: .value1, title: "WaniKani Level",
                                   subtitle: String(subjectAssignment.level)))


### PR DESCRIPTION
Fixes #448 by adding a new option to hide the stats section. The stats section will be on by default, to keep it the same way it is right now.

This also fixes #445 by reversing the default for `useKatakanaForOnyomi` accidentally changed in #382