### PR TITLE
Ignore passed items in current level

### DIFF
--- a/ios/CurrentLevelReviewTimeItem.swift
+++ b/ios/CurrentLevelReviewTimeItem.swift
@@ -59,7 +59,7 @@ private func calculateCurrentLevelReviewTime(services: TKMServices,
   let levelKanjiUnlocked = guruDates.last != nil ? (guruDates.last! != Date.distantFuture) : true
 
   for assignment in currentLevelAssignments {
-    if assignment
+    if assignment.hasPassedAt || assignment
       .subjectType == .vocabulary || (levelKanjiUnlocked && assignment.subjectType == .radical) {
       continue
     }


### PR DESCRIPTION
To follow with the original reasoning in #254, this PR will exclude assignments from being included that have already passed, since they are no longer relevant for level-up purposes.