### PR TITLE
Upcoming reviews list view (Fixes #274)

### DIFF
--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -30,6 +30,12 @@ struct ReviewComposition {
   var availableReviews = 0,
       countByType: [TKMSubject.TypeEnum: Int] = [.radical: 0, .kanji: 0, .vocabulary: 0],
       countByCategory: [SRSStageCategory: Int] = [.apprentice: 0, .guru: 0, .master: 0, .enlightened: 0]
+  
+  static func +(left: ReviewComposition, right: ReviewComposition) -> ReviewComposition {
+    ReviewComposition(availableReviews: left.availableReviews + right.availableReviews,
+                      countByType: left.countByType.merging(right.countByType, uniquingKeysWith: +),
+                      countByCategory: left.countByCategory.merging(right.countByCategory, uniquingKeysWith: +))
+  }
 }
 
 private func postNotificationOnMainQueue(_ notification: Notification.Name) {

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -161,7 +161,6 @@ class MainViewController: UITableViewController, LoginViewControllerDelegate,
   private func recreateTableModel() {
     guard let user = services.localCachingClient.getUserInfo() else { return }
 
-    let availableSubjects = services.localCachingClient.availableSubjects
     let lessons = services.localCachingClient.availableLessonCount
     let reviews = services.localCachingClient.availableReviewCount
     let upcomingReviews = services.localCachingClient.upcomingReviews
@@ -194,7 +193,8 @@ class MainViewController: UITableViewController, LoginViewControllerDelegate,
       model.add(reviewsItem)
 
       model.addSection("Upcoming reviews")
-      model.add(UpcomingReviewsChartItem(upcomingReviews, currentReviewCount: reviews, at: Date()))
+      model.add(UpcomingReviewsChartItem(upcomingReviews, currentReviewCount: reviews, at: Date(),
+                                         target: self, action: #selector(showTableForecast)))
       model
         .add(createCurrentLevelReviewTimeItem(services: services,
                                               currentLevelAssignments: currentLevelAssignments))
@@ -300,6 +300,10 @@ class MainViewController: UITableViewController, LoginViewControllerDelegate,
 
     case "settings":
       let vc = segue.destination as! SettingsViewController
+      vc.setup(services: services)
+
+    case "tableForecast":
+      let vc = segue.destination as! UpcomingReviewsViewController
       vc.setup(services: services)
 
     default:
@@ -483,6 +487,10 @@ class MainViewController: UITableViewController, LoginViewControllerDelegate,
 
   @objc func showAll() {
     performSegue(withIdentifier: "showAll", sender: self)
+  }
+
+  @objc func showTableForecast() {
+    performSegue(withIdentifier: "tableForecast", sender: self)
   }
 
   override var keyCommands: [UIKeyCommand]? {

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -168,6 +168,7 @@
                         <segue destination="Qs4-9j-s1J" kind="show" identifier="showRemaining" id="9oa-Qm-fW5"/>
                         <segue destination="MHj-tV-Wy7" kind="show" identifier="showAll" id="Gsa-0g-2hk"/>
                         <segue destination="HVF-EF-j9e" kind="show" identifier="settings" id="XTh-OI-gtz"/>
+                        <segue destination="vBH-2Y-r3P" kind="show" identifier="tableForecast" id="XTh-OP-gtz"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dob-5V-x24" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -277,6 +278,26 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pib-TB-EmN" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-727" y="834"/>
+        </scene>
+        <!--Upcoming Reviews View Controller-->
+        <scene sceneID="4xW-Gu-ryi">
+            <objects>
+                <tableViewController storyboardIdentifier="upcomingReviews" id="vBH-2Y-r3P" customClass="UpcomingReviewsViewController" customModule="Tsurukame" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" contentMode="scaleToFill" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="1YJ-wh-YRi">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <sections/>
+                        <connections>
+                            <outlet property="dataSource" destination="vBH-2Y-r3P" id="SNd-1o-sx1"/>
+                            <outlet property="delegate" destination="vBH-2Y-r3P" id="vv9-ub-Dbp"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="r5Y-Ak-tJZ"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CGk-60-mVf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1362" y="-493"/>
         </scene>
     </scenes>
     <resources>

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -146,6 +146,7 @@ private func getArchiveData<T: Codable>(_ defaultValue: T, key: String) -> T {
 
   @EnumSetting(InterfaceStyle.system,
                #keyPath(interfaceStyle)) static var interfaceStyle: InterfaceStyle
+  @Setting(false, #keyPath(upcomingTypeOverSRS)) static var upcomingTypeOverSRS: Bool
 
   @Setting(false, #keyPath(notificationsAllReviews)) static var notificationsAllReviews: Bool
   @Setting(true, #keyPath(notificationsBadging)) static var notificationsBadging: Bool

--- a/ios/SettingsViewController.swift
+++ b/ios/SettingsViewController.swift
@@ -44,8 +44,8 @@ class SettingsViewController: UITableViewController {
   private func rerender() {
     let model = TKMMutableTableModel(tableView: tableView)
 
+    model.addSection("App")
     if #available(iOS 13.0, *) {
-      model.addSection("App")
       model.add(TKMBasicModelItem(style: .value1,
                                   title: "UI Appearance",
                                   subtitle: Settings.interfaceStyle.description,
@@ -53,6 +53,12 @@ class SettingsViewController: UITableViewController {
                                   target: self,
                                   action: #selector(didTapInterfaceStyle(_:))))
     }
+    model.add(TKMSwitchModelItem(style: .subtitle,
+                                 title: "Upcoming type over SRS",
+                                 subtitle: "In the upcoming reviews list, break down item type instead of SRS.",
+                                 on: Settings.upcomingTypeOverSRS,
+                                 target: self,
+                                 action: #selector(upcomingTypeOverSRSChanged(_:))))
 
     model.addSection("Notifications")
     model.add(TKMSwitchModelItem(style: .default,
@@ -406,6 +412,10 @@ class SettingsViewController: UITableViewController {
 
   @objc private func playAudioAutomaticallySwitchChanged(_ switchView: UISwitch) {
     Settings.playAudioAutomatically = switchView.isOn
+  }
+
+  @objc private func upcomingTypeOverSRSChanged(_ switchView: UISwitch) {
+    Settings.upcomingTypeOverSRS = switchView.isOn
   }
 
   @objc private func allReviewsSwitchChanged(_ switchView: UISwitch) {

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		482D7C0F261CC29900104F69 /* ApprenticeLimitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482D7C0E261CC29900104F69 /* ApprenticeLimitViewController.swift */; };
 		483EBFDC261DD7190043C804 /* FontScreenshotterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4874562D261DD28E00F33AA3 /* FontScreenshotterUITests.swift */; };
 		48CF714823EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 48CF714623EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m */; };
+		48F4B1DC268CB9850033860E /* UpcomingReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F4B1DB268CB9850033860E /* UpcomingReviewsViewController.swift */; };
 		5C82B2908507339A293B0E59 /* Pods_FontScreenshotter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F33812F134DC80E5D981C40E /* Pods_FontScreenshotter.framework */; };
 		630ADB6F21F8256E00BC9801 /* TKMCheckmarkModelItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 630ADB6E21F8256E00BC9801 /* TKMCheckmarkModelItem.m */; };
 		630EB10A25C561A900783E54 /* NSMutableAttributedString+Replacements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630EB10925C561A900783E54 /* NSMutableAttributedString+Replacements.swift */; };
@@ -224,6 +225,7 @@
 		4874562E261DD28E00F33AA3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		489894D423670CB000A20AF8 /* Tsurukame.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tsurukame.entitlements; sourceTree = "<group>"; };
 		48CF714623EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TKMReviewBatchSizeViewController.m; sourceTree = "<group>"; };
+		48F4B1DB268CB9850033860E /* UpcomingReviewsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpcomingReviewsViewController.swift; sourceTree = "<group>"; };
 		4B8236EC341CF1BA18D16857 /* Pods-Tsurukame-Tsurukame Complication Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tsurukame-Tsurukame Complication Extension.release.xcconfig"; path = "Target Support Files/Pods-Tsurukame-Tsurukame Complication Extension/Pods-Tsurukame-Tsurukame Complication Extension.release.xcconfig"; sourceTree = "<group>"; };
 		630ADB6D21F8256E00BC9801 /* TKMCheckmarkModelItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TKMCheckmarkModelItem.h; sourceTree = "<group>"; };
 		630ADB6E21F8256E00BC9801 /* TKMCheckmarkModelItem.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TKMCheckmarkModelItem.m; sourceTree = "<group>"; };
@@ -578,6 +580,7 @@
 				63C42A4421B6A703008CA938 /* Tsurukame-Bridging-Header.h */,
 				6319C9B520441DE200C31F87 /* Tsurukame.app */,
 				93B59B292367AF130097533C /* UpcomingReviewsChartItem.swift */,
+				48F4B1DB268CB9850033860E /* UpcomingReviewsViewController.swift */,
 				633AFAE52352B6F2004F732F /* VocabularyHighlighter.swift */,
 				63CAB4F72605F9AF0057E1C2 /* WaniKaniAPI */,
 				C92AB96E237F280300F79904 /* WatchHelper.swift */,
@@ -1265,6 +1268,7 @@
 				63CE766321F47100002A417B /* TKMReviewContainerViewController.m in Sources */,
 				63C74BD125C82B1D004F6C99 /* SubjectCollectionModelItem.swift in Sources */,
 				63FCAE78237F75CC00DB1418 /* Style.swift in Sources */,
+				48F4B1DC268CB9850033860E /* UpcomingReviewsViewController.swift in Sources */,
 				63C74C7F25C96F58004F6C99 /* SubjectDelegate.swift in Sources */,
 				63D1026923D7ED3200838F7C /* UIWindow+InterfaceStyle.swift in Sources */,
 			);

--- a/ios/UpcomingReviewsChartItem.swift
+++ b/ios/UpcomingReviewsChartItem.swift
@@ -40,12 +40,12 @@ class UpcomingReviewsXAxisValueFormatter: IAxisValueFormatter {
 class UpcomingReviewsChartItem: NSObject, TKMModelItem {
   let upcomingReviews: [Int]
   let currentReviewCount: Int
-  let target: MainViewController
+  let target: NSObject
   let action: Selector
   let date: Date
 
   @objc init(_ upcomingReviews: [Int], currentReviewCount: Int, at date: Date,
-             target: MainViewController, action: Selector) {
+             target: NSObject, action: Selector) {
     self.upcomingReviews = upcomingReviews
     self.currentReviewCount = currentReviewCount
     self.date = date
@@ -64,7 +64,7 @@ class UpcomingReviewsChartItem: NSObject, TKMModelItem {
 
 class UpcomingReviewsChartCell: TKMModelCell {
   private let view: CombinedChartView
-  private var mainVC: MainViewController!
+  private var targetController: NSObject!
   private var action: Selector!
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -102,7 +102,7 @@ class UpcomingReviewsChartCell: TKMModelCell {
 
   override func update(with baseItem: TKMModelItem!) {
     let item = baseItem as! UpcomingReviewsChartItem
-    mainVC = item.target
+    targetController = item.target
     action = item.action
 
     var hourlyData = [BarChartDataEntry]()
@@ -149,6 +149,6 @@ class UpcomingReviewsChartCell: TKMModelCell {
   }
 
   override func didSelect() {
-    mainVC.perform(action)
+    targetController.perform(action)
   }
 }

--- a/ios/UpcomingReviewsChartItem.swift
+++ b/ios/UpcomingReviewsChartItem.swift
@@ -18,11 +18,12 @@ import Foundation
 class UpcomingReviewsXAxisValueFormatter: IAxisValueFormatter {
   let startTime: Date
   let dateFormatter: DateFormatter
+  let hourFormat: String = "ha"
 
   init(_ startTime: Date) {
     self.startTime = startTime
     dateFormatter = DateFormatter()
-    dateFormatter.setLocalizedDateFormatFromTemplate("ha")
+    dateFormatter.setLocalizedDateFormatFromTemplate(hourFormat)
   }
 
   func stringForValue(_ value: Double, axis _: AxisBase?) -> String {
@@ -39,12 +40,17 @@ class UpcomingReviewsXAxisValueFormatter: IAxisValueFormatter {
 class UpcomingReviewsChartItem: NSObject, TKMModelItem {
   let upcomingReviews: [Int]
   let currentReviewCount: Int
+  let target: MainViewController
+  let action: Selector
   let date: Date
 
-  @objc init(_ upcomingReviews: [Int], currentReviewCount: Int, at date: Date) {
+  @objc init(_ upcomingReviews: [Int], currentReviewCount: Int, at date: Date,
+             target: MainViewController, action: Selector) {
     self.upcomingReviews = upcomingReviews
     self.currentReviewCount = currentReviewCount
     self.date = date
+    self.target = target
+    self.action = action
   }
 
   func cellClass() -> AnyClass! {
@@ -58,6 +64,8 @@ class UpcomingReviewsChartItem: NSObject, TKMModelItem {
 
 class UpcomingReviewsChartCell: TKMModelCell {
   private let view: CombinedChartView
+  private var mainVC: MainViewController!
+  private var action: Selector!
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     view = CombinedChartView()
@@ -94,6 +102,8 @@ class UpcomingReviewsChartCell: TKMModelCell {
 
   override func update(with baseItem: TKMModelItem!) {
     let item = baseItem as! UpcomingReviewsChartItem
+    mainVC = item.target
+    action = item.action
 
     var hourlyData = [BarChartDataEntry]()
     var cumulativeData = [ChartDataEntry]()
@@ -136,5 +146,9 @@ class UpcomingReviewsChartCell: TKMModelCell {
 
     view.data = data
     view.xAxis.valueFormatter = UpcomingReviewsXAxisValueFormatter(item.date)
+  }
+
+  override func didSelect() {
+    mainVC.perform(action)
   }
 }

--- a/ios/UpcomingReviewsViewController.swift
+++ b/ios/UpcomingReviewsViewController.swift
@@ -44,19 +44,11 @@ class UpcomingReviewsViewController: UITableViewController {
     rerender()
   }
 
-  private typealias ReviewData = ReviewComposition
-
-  private func combineData(_ a: ReviewData, _ b: ReviewData) -> ReviewData {
-    return ReviewData(availableReviews: a.availableReviews + b.availableReviews,
-                      countByType: a.countByType.merging(b.countByType, uniquingKeysWith: +),
-                      countByCategory: a.countByCategory.merging(b.countByCategory, uniquingKeysWith: +))
-  }
-
-  private func getReviewData() -> [ReviewData] {
+  private func getReviewData() -> [ReviewComposition] {
     let subjects = services.localCachingClient.availableSubjects
-    var cumulativeData: [ReviewData] = []
+    var cumulativeData: [ReviewComposition] = []
     for data in subjects.reviewComposition {
-      cumulativeData.append(combineData(cumulativeData.last ?? ReviewData(), data))
+      cumulativeData.append(data + (cumulativeData.last ?? ReviewComposition()))
     }
     return cumulativeData
   }

--- a/ios/UpcomingReviewsViewController.swift
+++ b/ios/UpcomingReviewsViewController.swift
@@ -1,0 +1,90 @@
+// Copyright 2021 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+private class UpcomingReviewsDateFormatter: UpcomingReviewsXAxisValueFormatter {
+  override init(_ startTime: Date) {
+    super.init(startTime)
+    dateFormatter.setLocalizedDateFormatFromTemplate("d MMM \(hourFormat)")
+  }
+
+  func string(hour: Int) -> String {
+    let date = startTime.addingTimeInterval(TimeInterval(hour * 60 * 60))
+    return dateFormatter.string(from: date)
+  }
+}
+
+class UpcomingReviewsViewController: UITableViewController {
+  private var services: TKMServices!
+  private var date: UpcomingReviewsDateFormatter!
+  private var model: TKMTableModel?
+
+  func setup(services: TKMServices) {
+    self.services = services
+  }
+
+  // MARK: - UIView
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    navigationController?.isNavigationBarHidden = false
+    date = UpcomingReviewsDateFormatter(Date())
+    rerender()
+  }
+
+  private typealias ReviewData = ReviewComposition
+
+  private func combineData(_ a: ReviewData, _ b: ReviewData) -> ReviewData {
+    return ReviewData(availableReviews: a.availableReviews + b.availableReviews,
+                      countByType: a.countByType.merging(b.countByType, uniquingKeysWith: +),
+                      countByCategory: a.countByCategory.merging(b.countByCategory, uniquingKeysWith: +))
+  }
+
+  private func getReviewData() -> [ReviewData] {
+    let subjects = services.localCachingClient.availableSubjects
+    var cumulativeData: [ReviewData] = []
+    for data in subjects.reviewComposition {
+      cumulativeData.append(combineData(cumulativeData.last ?? ReviewData(), data))
+    }
+    return cumulativeData
+  }
+
+  private func rerender() {
+    let model = TKMMutableTableModel(tableView: tableView),
+        reviewData = getReviewData()
+
+    func formatData(hour: Int) -> String {
+      let data = reviewData[hour],
+          difference = data.availableReviews - (hour > 0 ? reviewData[hour - 1].availableReviews : 0)
+      return "\(data.availableReviews) (+\(difference)): " +
+        (Settings.upcomingTypeOverSRS ? data.countByType.reduce("") {
+          $0.isEmpty ? "\($1.value)" : "\($0)/\($1.value)"
+        } : data.countByCategory.reduce("") {
+          $0.isEmpty ? "\($1.value)" : "\($0)/\($1.value)"
+        })
+    }
+
+    for hour in 0 ..< reviewData.count {
+      if hour > 0, reviewData[hour].availableReviews == reviewData[hour - 1].availableReviews { continue }
+      model.add(TKMBasicModelItem(style: .value1,
+                                  title: date.string(hour: hour),
+                                  subtitle: formatData(hour: hour),
+                                  accessoryType: .none))
+    }
+
+    self.model = model
+    model.reloadTable()
+  }
+}


### PR DESCRIPTION
Implements the first half of #112 by adding the list, and fixes #274 by breaking down the review count in the list by SRS (which can be toggled to item type)

The list is opened by tapping the graph, as if for more details.