### PR TITLE
Fix useless exact match & unshowable subject details

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1024,7 +1024,8 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     case .Precise:
       markAnswer(.Correct)
     case .Imprecise:
-      markAnswer(.Correct)
+      if Settings.exactMatch { shakeView(answerField) }
+      else { markAnswer(.Correct) }
     case .Incorrect:
       markAnswer(.Incorrect)
     case .OtherKanjiReading:

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -378,6 +378,7 @@ class SubjectDetailsView: UITableView, SubjectChipDelegate {
         addFormattedText(subject.vocabulary.meaningExplanation,
                          isHint: false, toModel: model)
       }
+      // Reading explanations often contain the meaning, so require it as well
       if meaningShown, readingShown {
         model.addSection("Reading Explanation")
         addFormattedText(subject.vocabulary.readingExplanation,

--- a/utils/set-team-product.sh
+++ b/utils/set-team-product.sh
@@ -33,7 +33,7 @@ cp "${MAIN_PROJ}" "${BKP_PROJ}"
 sed 's|DEVELOPMENT_TEAM = .*;|DEVELOPMENT_TEAM = '"${DEVELOPMENT_TEAM}"';|g' "${MAIN_PROJ}" > "${TEMP_PROJ}.1"
 
 # Step 2: Change PRODUCT_BUNDLE_IDENTIFIER
-sed 's|PRODUCT_BUNDLE_IDENTIFIER = com.[^.]*\.[^.;]*|PRODUCT_BUNDLE_IDENTIFIER = '"${PRODUCT_ID}"'|g' "${TEMP_PROJ}.1" > "${TEMP_PROJ}.2"
+sed 's|PRODUCT_BUNDLE_IDENTIFIER = com\.[^.]*\.[^.;]*|PRODUCT_BUNDLE_IDENTIFIER = '"${PRODUCT_ID}"'|g' "${TEMP_PROJ}.1" > "${TEMP_PROJ}.2"
 
 # Copy back into place
 cp "${TEMP_PROJ}.2" "${MAIN_PROJ}"
@@ -44,7 +44,7 @@ WATCH_TEMP="/tmp/watch.plist"
 
 # Step 3: Watch complication Info.plist
 if [[ -f "${WATCH_PLIST}" ]];then
-  sed 's|com.[^.]*\.[^.<]*|'"${PRODUCT_ID}"'|g' "${WATCH_PLIST}" > "$WATCH_TEMP"
+  sed 's|com\.[^.]*\.[^.<]*|'"${PRODUCT_ID}"'|g' "${WATCH_PLIST}" > "$WATCH_TEMP"
   cp "$WATCH_TEMP" "${WATCH_PLIST}"
 
   # Step 4: Watch complication extension Info.plist


### PR DESCRIPTION
Due to bugs, the exact match setting does nothing, the script to change bundle identifers incorrectly matches the doctypes in the complication property lists, and if you review and get the reading wrong but haven't answered the meaning, or vice versa, there's no way to show the meaning and its explanation.

By fixing these bugs, this PR will resolve #86, resolve #172, and resolve #463.