### PR TITLE
Add toggle for newly fixed exact match setting so users can set it

### DIFF
--- a/ios/SettingsViewController.swift
+++ b/ios/SettingsViewController.swift
@@ -147,6 +147,12 @@ class SettingsViewController: UITableViewController {
                                 action: #selector(fontSizeChanged(_:))))
 
     model.add(TKMSwitchModelItem(style: .subtitle,
+                                     title: "Exact match",
+                                     subtitle: "Requires typing in answers exactly correct",
+                                     on: Settings.exactMatch,
+                                     target: self,
+                                     action: #selector(exactMatchSwitchChanged(_:))))
+    model.add(TKMSwitchModelItem(style: .subtitle,
                                  title: "Allow cheating",
                                  subtitle: "Ignore Typos and Add Synonym",
                                  on: Settings.enableCheats,
@@ -330,6 +336,10 @@ class SettingsViewController: UITableViewController {
 
   @objc private func minimizeReviewPenaltySwitchChanged(_ switchView: UISwitch) {
     Settings.minimizeReviewPenalty = switchView.isOn
+  }
+
+  @objc private func exactMatchSwitchChanged(_ switchView: UISwitch) {
+    Settings.exactMatch = switchView.isOn
   }
 
   @objc private func enableCheatsSwitchChanged(_ switchView: UISwitch) {

--- a/ios/SettingsViewController.swift
+++ b/ios/SettingsViewController.swift
@@ -147,11 +147,11 @@ class SettingsViewController: UITableViewController {
                                 action: #selector(fontSizeChanged(_:))))
 
     model.add(TKMSwitchModelItem(style: .subtitle,
-                                     title: "Exact match",
-                                     subtitle: "Requires typing in answers exactly correct",
-                                     on: Settings.exactMatch,
-                                     target: self,
-                                     action: #selector(exactMatchSwitchChanged(_:))))
+                                 title: "Exact match",
+                                 subtitle: "Requires typing in answers exactly correct",
+                                 on: Settings.exactMatch,
+                                 target: self,
+                                 action: #selector(exactMatchSwitchChanged(_:))))
     model.add(TKMSwitchModelItem(style: .subtitle,
                                  title: "Allow cheating",
                                  subtitle: "Ignore Typos and Add Synonym",


### PR DESCRIPTION
The bug fixes in #478 seem to have accidentally forgotten to add the exact match setting to SettingsViewController. This PR corrects that.