### PR TITLE
Include number of newly available reviews in the notification

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -213,8 +213,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, LoginViewControllerDelega
           let identifier = "badge-\(hour)"
           let content = UNMutableNotificationContent()
           if Settings.notificationsAllReviews {
-            content
-              .body = "\(cumulativeReviews) review\(cumulativeReviews == 1 ? "" : "s") available"
+            content.body = "\(cumulativeReviews) review\(cumulativeReviews == 1 ? "" : "s") " +
+                            "available (\(upcomingReviews[hour]) new)"
           }
           if Settings.notificationsBadging {
             content.badge = NSNumber(value: cumulativeReviews)


### PR DESCRIPTION
Implements the first point of #362 by including how many of the reviews newly available are new reviews in the notification.