### PR TITLE
Fix Anki mode conflicts with reveal immediately & skipping reviews

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -611,6 +611,9 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
         submitButton.setImage(skipImage, for: .normal)
       } else if !Settings.ankiMode {
         submitButton.isEnabled = false
+      } else {
+        // Hide the submit button in Anki mode if skipping reviews are off
+        submitButton.isHidden = true
       }
 
       // Background gradients.
@@ -744,13 +747,19 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
 
     if shown {
       subjectDetailsView.isHidden = false
-      if cheats {
+      if cheats, !Settings.ankiMode {
         addSynonymButton.isHidden = false
+      }
+      if Settings.ankiMode, Settings.allowSkippingReviews {
+        submitButton.isHidden = true
       }
     } else {
       if previousSubject != nil {
         previousSubjectLabel?.isHidden = false
         previousSubjectButton.isHidden = false
+      }
+      if Settings.ankiMode, Settings.allowSkippingReviews {
+        submitButton.isHidden = false
       }
     }
 
@@ -910,6 +919,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
 
   @objc func didShortPressQuestionLabel(_: UITapGestureRecognizer) {
     toggleFont()
+    if Settings.ankiMode { submit() }
   }
 
   @objc func didSwipeQuestionLabel(_ sender: UISwipeGestureRecognizer) {
@@ -1208,7 +1218,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     }
 
     // Otherwise show the correct answer.
-    if !Settings.showAnswerImmediately {
+    if !Settings.showAnswerImmediately, !Settings.ankiMode {
       revealAnswerButton.isHidden = false
       UIView.animate(withDuration: animationDuration,
                      animations: {

--- a/ios/SettingsViewController.swift
+++ b/ios/SettingsViewController.swift
@@ -216,7 +216,7 @@ class SettingsViewController: UITableViewController {
                                      action: #selector(partiallyCorrectSwitchChanged(_:))))
     model.add(TKMSwitchModelItem(style: .subtitle,
                                  title: "Anki mode",
-                                 subtitle: "Allows doing reviews without typing answers",
+                                 subtitle: "Do reviews without typing answers",
                                  on: Settings.ankiMode,
                                  target: self,
                                  action: #selector(ankiModeSwitchChanged(_:))))


### PR DESCRIPTION
Wider testing revealed that Anki mode conflicted with the reveal answer immediately and skipping reviews settings.

This PR fixes that by hiding all buttons that are present in non-Anki mode reviews, and building in a submit functionality when pressing the question label.