### PR TITLE
Fix crash on empty array by using dropFirst() instead of [1...]

### DIFF
--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -983,7 +983,7 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
   }
 
   var upcomingReviews: [Int] {
-    availableSubjects.reviewComposition[1...].map { return $0.availableReviews }
+    availableSubjects.reviewComposition.dropFirst().map { return $0.availableReviews }
   }
 }
 


### PR DESCRIPTION
In the event `availableSubjects.reviewComposition` is an empty array, using a range to create an ArraySlice will fail. Using `dropFirst()` to create it removes this risk, since it falls back on an empty array if the array is too small.