### PR TITLE
Meaning only back-to-back order for lightning Anki reviews

### DIFF
--- a/ios/Resources/Settings.storyboard
+++ b/ios/Resources/Settings.storyboard
@@ -252,6 +252,23 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="hEF-Ru-ZjH" style="IBUITableViewCellStyleDefault" id="fyR-Bw-W2T">
+                                        <rect key="frame" x="0.0" y="116" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fyR-Bw-W2T" id="dgq-zb-OSh">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Meaning and Reading (Anki mode only)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hEF-Ru-ZjH">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>

--- a/ios/ReviewTaskOrderViewController.m
+++ b/ios/ReviewTaskOrderViewController.m
@@ -23,7 +23,7 @@
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  NSInteger selectedRow = Settings.meaningFirst ? 0 : 1;
+  NSInteger selectedRow = Settings.meaningOnly ? 2 : (Settings.meaningFirst ? 0 : 1);
   if (selectedRow < 0 || selectedRow >= [self.tableView numberOfRowsInSection:0]) {
     selectedRow = 0;
   }
@@ -34,7 +34,8 @@
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-  Settings.meaningFirst = indexPath.row == 0;
+  Settings.meaningFirst = indexPath.row != 1;
+  Settings.meaningOnly = indexPath.row == 2;
   [self.navigationController popViewControllerAnimated:YES];
 }
 

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -550,7 +550,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
       } else if activeTask.answeredReading || activeSubject.hasRadical {
         activeTaskType = .meaning
       } else if Settings.groupMeaningReading {
-        activeTaskType = Settings.meaningFirst ? .meaning : .reading
+        activeTaskType = Settings.meaningFirst || Settings.meaningOnly ? .meaning : .reading
       } else {
         activeTaskType = TaskType.random()
       }
@@ -1164,8 +1164,8 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     }
 
     // Remove it from the active queue if that was the last part.
-    let isSubjectFinished =
-      activeTask.answeredMeaning && (activeSubject.hasRadical || activeTask.answeredReading)
+    let isSubjectFinished = activeTask.answeredMeaning &&
+      (Settings.meaningOnly || activeSubject.hasRadical || activeTask.answeredReading)
     let didLevelUp = (!activeTask.answer.readingWrong && !activeTask.answer.meaningWrong)
     let newSrsStage =
       didLevelUp ? activeTask.assignment.srsStage.next : activeTask.assignment.srsStage.previous

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -164,6 +164,7 @@ private func getArchiveData<T: Codable>(_ defaultValue: T, key: String) -> T {
   @Setting(Int.max, #keyPath(apprenticeLessonsLimit)) static var apprenticeLessonsLimit: Int
   @Setting(false, #keyPath(groupMeaningReading)) static var groupMeaningReading: Bool
   @Setting(true, #keyPath(meaningFirst)) static var meaningFirst: Bool
+  @Setting(false, #keyPath(meaningOnly)) static var meaningOnly: Bool
   @Setting(true, #keyPath(showAnswerImmediately)) static var showAnswerImmediately: Bool
   @Setting([], #keyPath(selectedFonts)) static var selectedFonts: Set<String>
   @Setting(1.0, #keyPath(fontSize)) static var fontSize: Float

--- a/ios/SettingsViewController.swift
+++ b/ios/SettingsViewController.swift
@@ -311,7 +311,8 @@ class SettingsViewController: UITableViewController {
   }
 
   private var taskOrderValueText: String {
-    Settings.meaningFirst ? "Meaning first" : "Reading first"
+    Settings.meaningFirst ? "Meaning first" :
+      Settings.meaningOnly ? "Meaning only" : "Reading first"
   }
 
   private var fontSizeValueText: String {


### PR DESCRIPTION
Intended to make Anki mode reviews faster, this draft pull request proposes to add a back-to-back option to only test the meaning, so people can answer whether they got both the meaning and reading correct in one go to save button presses.