### PR TITLE
Use reveal answer automatically to reveal Anki mark answer pop-up

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1050,7 +1050,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     if Settings.ankiMode {
       // Mark the answer incorrect to show the details. This can still be overriden.
       if subjectDetailsView.isHidden { markAnswer(.Incorrect) }
-      addSynonymButtonPressed(true)
+      if Settings.showAnswerImmediately || !subjectDetailsView.isHidden { addSynonymButtonPressed(true) }
       return
     }
 

--- a/ios/SettingsViewController.swift
+++ b/ios/SettingsViewController.swift
@@ -127,9 +127,9 @@ class SettingsViewController: UITableViewController {
                                                                action: #selector(didTapTaskOrder(_:))),
                                              hidden:!Settings
                                                .groupMeaningReading)
-    model.add(TKMSwitchModelItem(style: .default,
+    model.add(TKMSwitchModelItem(style: .subtitle,
                                  title: "Reveal answer automatically",
-                                 subtitle: nil,
+                                 subtitle: "In Anki mode, this reveals the mark answer pop-up instead.",
                                  on: Settings.showAnswerImmediately,
                                  target: self,
                                  action: #selector(showAnswerImmediatelySwitchChanged(_:))))


### PR DESCRIPTION
Fixes #494 by using the existing reveal answer automatically setting to toggle the instant revealing of the Anki mode mark answer pop-up.

Since this setting is already a quick setting in the menu, it can be toggled without leaving reviews.