### PR TITLE
Fix bug in #495

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1049,8 +1049,9 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
   func submit() {
     if Settings.ankiMode {
       // Mark the answer incorrect to show the details. This can still be overriden.
-      if subjectDetailsView.isHidden { markAnswer(.Incorrect) }
-      if Settings.showAnswerImmediately || !subjectDetailsView.isHidden { addSynonymButtonPressed(true) }
+      let answersRevealed = !subjectDetailsView.isHidden
+      if !answersRevealed { markAnswer(.Incorrect) }
+      if Settings.showAnswerImmediately || answersRevealed { addSynonymButtonPressed(true) }
       return
     }
 


### PR DESCRIPTION
In trying to implement #495, I got overconfident and forgot to test. As it turns out, once the answer is marked incorrect, the subject details view is always shown, so the value of what it was before needs to be saved.