### PR TITLE
Add burned field to stats section

### DIFF
--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -430,6 +430,11 @@ class SubjectDetailsView: UITableView, SubjectChipDelegate {
                                       subtitle: statsDateFormatter
                                         .string(from: subjectAssignment.passedAtDate)))
         }
+        if subjectAssignment.hasBurnedAt {
+          model.add(TKMBasicModelItem(style: .value1, title: "Burned",
+                                      subtitle: statsDateFormatter
+                                        .string(from: subjectAssignment.burnedAtDate)))
+        }
       }
 
       // TODO: When possible in the API, add a resurrect button.

--- a/ios/WaniKaniAPI/Sources/WaniKaniAPI/APIClient.swift
+++ b/ios/WaniKaniAPI/Sources/WaniKaniAPI/APIClient.swift
@@ -637,6 +637,7 @@ private struct AssignmentData: Codable {
   var unlocked_at: WaniKaniDate?
   var started_at: WaniKaniDate?
   var passed_at: WaniKaniDate?
+  var burned_at: WaniKaniDate?
   var available_at: WaniKaniDate?
 
   func toProto(id: Int32?, subjectLevelGetter: SubjectLevelGetter) -> TKMAssignment {
@@ -648,6 +649,7 @@ private struct AssignmentData: Codable {
     toProtoDate(available_at) { ret.availableAt = $0 }
     toProtoDate(started_at) { ret.startedAt = $0 }
     toProtoDate(passed_at) { ret.passedAt = $0 }
+    toProtoDate(burned_at) { ret.burnedAt = $0 }
 
     switch subject_type {
     case "radical":

--- a/ios/WaniKaniAPI/Sources/WaniKaniAPI/ProtobufExtensions.swift
+++ b/ios/WaniKaniAPI/Sources/WaniKaniAPI/ProtobufExtensions.swift
@@ -362,6 +362,7 @@ public extension TKMAssignment {
   var availableAtDate: Date { Date(timeIntervalSince1970: TimeInterval(availableAt)) }
   var startedAtDate: Date { Date(timeIntervalSince1970: TimeInterval(startedAt)) }
   var passedAtDate: Date { Date(timeIntervalSince1970: TimeInterval(passedAt)) }
+  var burnedAtDate: Date { Date(timeIntervalSince1970: TimeInterval(burnedAt)) }
 
   var reviewDate: Date? {
     if isBurned || isLocked {

--- a/ios/WaniKaniAPI/Sources/WaniKaniAPI/wanikani_api.pb.swift
+++ b/ios/WaniKaniAPI/Sources/WaniKaniAPI/wanikani_api.pb.swift
@@ -742,6 +742,15 @@ public struct TKMAssignment {
   /// Clears the value of `passedAt`. Subsequent reads from it will return its default value.
   public mutating func clearPassedAt() {self._passedAt = nil}
 
+  public var burnedAt: Int32 {
+    get {return _burnedAt ?? 0}
+    set {_burnedAt = newValue}
+  }
+  /// Returns true if `burnedAt` has been explicitly set.
+  public var hasBurnedAt: Bool {return self._burnedAt != nil}
+  /// Clears the value of `burnedAt`. Subsequent reads from it will return its default value.
+  public mutating func clearBurnedAt() {self._burnedAt = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -754,6 +763,7 @@ public struct TKMAssignment {
   fileprivate var _startedAt: Int32? = nil
   fileprivate var _srsStageNumber: Int32? = nil
   fileprivate var _passedAt: Int32? = nil
+  fileprivate var _burnedAt: Int32? = nil
 }
 
 public struct TKMProgress {
@@ -1750,6 +1760,7 @@ extension TKMAssignment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
     6: .standard(proto: "started_at"),
     7: .standard(proto: "srs_stage_number"),
     8: .standard(proto: "passed_at"),
+    9: .standard(proto: "burned_at"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1766,6 +1777,7 @@ extension TKMAssignment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
       case 6: try { try decoder.decodeSingularInt32Field(value: &self._startedAt) }()
       case 7: try { try decoder.decodeSingularInt32Field(value: &self._srsStageNumber) }()
       case 8: try { try decoder.decodeSingularInt32Field(value: &self._passedAt) }()
+      case 9: try { try decoder.decodeSingularInt32Field(value: &self._burnedAt) }()
       default: break
       }
     }
@@ -1796,6 +1808,9 @@ extension TKMAssignment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
     if let v = self._passedAt {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 8)
     }
+    if let v = self._burnedAt {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 9)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1808,6 +1823,7 @@ extension TKMAssignment: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
     if lhs._startedAt != rhs._startedAt {return false}
     if lhs._srsStageNumber != rhs._srsStageNumber {return false}
     if lhs._passedAt != rhs._passedAt {return false}
+    if lhs._burnedAt != rhs._burnedAt {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/proto/wanikani_api.proto
+++ b/proto/wanikani_api.proto
@@ -148,6 +148,7 @@ message Assignment {
   optional int32 started_at = 6;
   optional int32 srs_stage_number = 7;
   optional int32 passed_at = 8;
+  optional int32 burned_at = 9;
 }
 
 message Progress {


### PR DESCRIPTION
This PR allows users to see the date they have burned an item in the stats section.

For future reference, in order for the burned date to be cached into the client the first time, users would have to perform a full refresh (since caches created prior, of course, wouldn't contain the burned at date).