### PR TITLE
Format recently inserted lines

### DIFF
--- a/ios/FontLoader.swift
+++ b/ios/FontLoader.swift
@@ -56,7 +56,7 @@ struct FontDefinition {
     super.init()
     reload()
   }
-  
+
   func canRender(_ text: String) -> Bool {
     let fontRef = CTFontCreateWithName(NSString(string: fontName), 0.0, nil)
     let count = text.count, characters = text.utf16.map { $0 }

--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -31,11 +31,12 @@ struct ReviewComposition {
       countByType: [TKMSubject.TypeEnum: Int] = [.radical: 0, .kanji: 0, .vocabulary: 0],
       countByCategory: [SRSStageCategory: Int] = [.apprentice: 0, .guru: 0, .master: 0,
                                                   .enlightened: 0]
-  
-  static func +(left: ReviewComposition, right: ReviewComposition) -> ReviewComposition {
+
+  static func + (left: ReviewComposition, right: ReviewComposition) -> ReviewComposition {
     ReviewComposition(availableReviews: left.availableReviews + right.availableReviews,
                       countByType: left.countByType.merging(right.countByType, uniquingKeysWith: +),
-                      countByCategory: left.countByCategory.merging(right.countByCategory, uniquingKeysWith: +))
+                      countByCategory: left.countByCategory.merging(right.countByCategory,
+                                                                    uniquingKeysWith: +))
   }
 }
 

--- a/ios/UpcomingReviewsViewController.swift
+++ b/ios/UpcomingReviewsViewController.swift
@@ -59,18 +59,18 @@ class UpcomingReviewsViewController: UITableViewController {
 
     func formatData(hour: Int) -> String {
       let data = reviewData[hour],
-          difference = data.availableReviews - (hour > 0 ? reviewData[hour - 1].availableReviews : 0)
-      return "\(data.availableReviews) (+\(difference)): " +
-        (Settings.upcomingTypeOverSRS ?
-          data.countByType.sorted{$0.key.rawValue < $1.key.rawValue}.reduce("") {
-            $0.isEmpty ? "\($1.value)" : "\($0)/\($1.value)"
-          } : data.countByCategory.sorted{$0.key.rawValue < $1.key.rawValue}.reduce("") {
-            $0.isEmpty ? "\($1.value)" : "\($0)/\($1.value)"
-          })
+          diff = data.availableReviews - (hour > 0 ? reviewData[hour - 1].availableReviews : 0)
+      return "\(data.availableReviews) (+\(diff)): " + (Settings.upcomingTypeOverSRS ?
+        data.countByType.sorted { $0.key.rawValue < $1.key.rawValue }.reduce("") {
+          $0.isEmpty ? "\($1.value)" : "\($0)/\($1.value)"
+        } : data.countByCategory.sorted { $0.key.rawValue < $1.key.rawValue }.reduce("") {
+          $0.isEmpty ? "\($1.value)" : "\($0)/\($1.value)"
+        })
     }
 
     for hour in 0 ..< reviewData.count {
-      if hour > 0, reviewData[hour].availableReviews == reviewData[hour - 1].availableReviews { continue }
+      if hour > 0,
+         reviewData[hour].availableReviews == reviewData[hour - 1].availableReviews { continue }
       model.add(TKMBasicModelItem(style: .value1,
                                   title: date.string(hour: hour),
                                   subtitle: formatData(hour: hour),


### PR DESCRIPTION
This PR makes a few manual formatting adjustments, and then ran SwiftFormat.

Please note the space inserted on line 35 of `LocalCachingClient.swift`. If you think it looks cleaner, you don't need to do anything. However, if you don't like it, you'll need to add the SwiftFormat rule `--operatorfunc no-space`