### PR TITLE
App Group Data

### DIFF
--- a/ios/AppGroup.swift
+++ b/ios/AppGroup.swift
@@ -1,0 +1,210 @@
+// Copyright 2021 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+#if canImport(WidgetKit)
+  import WidgetKit
+#endif
+
+// MARK: - CodedWidgetData
+
+public struct CodedWidgetData: Codable {
+  public var lessons: Int = -2
+  public var reviews: Int = -2
+  public var reviewForecast: [Int] = []
+  public var date = Date()
+
+  public var isDefault: Bool { lessons == -2 && reviews == -2 }
+  public var isSample: Bool { lessons == -1 && reviews == -1 }
+}
+
+extension CodedWidgetData {
+  init(sampleData: Bool) {
+    guard sampleData else {
+      self.init()
+      return
+    }
+    self.init(lessons: -1, reviews: -1, reviewForecast: [], date: Date())
+  }
+}
+
+// MARK: - ReviewCounts
+
+public struct ReviewCounts: Codable, Hashable, Identifiable {
+  public var id = UUID()
+  public var date: Date
+  public var total: Int
+  public var new: Int
+
+  static func projectedReviews(from data: CodedWidgetData) -> [ReviewCounts] {
+    var date = data.date.hourTruncated!, total = data.reviews, forecast: [ReviewCounts] = []
+    for newReviews in data.reviewForecast {
+      date += 3600
+      total += newReviews
+      forecast.append(ReviewCounts(date: date, total: total, new: newReviews))
+    }
+    return forecast
+  }
+}
+
+// MARK: - ExpandedWidgetData
+
+public struct ExpandedWidgetData: Codable {
+  public var date: Date
+  public var lessons: Int
+  public var reviewForecast: [ReviewCounts]
+
+  public var reviews: Int { (reviewForecast.first?.total ?? 0) - (reviewForecast.first?.new ?? 0) }
+
+  public func projected(for date: Date) -> ExpandedWidgetData {
+    var projectedCounts = reviewForecast
+    while projectedCounts.count > 0 {
+      guard projectedCounts.first!.date <= date else { break }
+      projectedCounts.removeFirst()
+    }
+    return ExpandedWidgetData(date: date, lessons: lessons, reviewForecast: projectedCounts)
+  }
+
+  public func todayForecast(for date: Date) -> [ReviewCounts] {
+    var todayForecast: [ReviewCounts] = []
+    for forecastEntry in reviewForecast {
+      if forecastEntry.date.dateString == date.dateString {
+        todayForecast.append(forecastEntry)
+      }
+    }
+    return todayForecast
+  }
+
+  public func weekDailyReviewForecast(after date: Date) -> [DailyReviews] {
+    var workingDate = "", hasReachedTargetDate = false, dailyReviews: [DailyReviews] = []
+    for counts in reviewForecast {
+      guard counts.date.dateString != date.dateString else {
+        hasReachedTargetDate = true
+        continue
+      }
+      guard hasReachedTargetDate else { continue }
+      if counts.date.dateString != workingDate {
+        dailyReviews.append(DailyReviews(counts: [counts]))
+        workingDate = counts.date.dateString
+        continue
+      }
+      dailyReviews[dailyReviews.count - 1].append(counts)
+    }
+    return Array(dailyReviews[0 ... 6])
+  }
+}
+
+// MARK: - DailyReviews
+
+public struct DailyReviews: Codable, Hashable, Identifiable {
+  public static let hours = [0, 3, 7, 11, 15, 19, 23]
+
+  public var id = UUID()
+  private var counts: [ReviewCounts] = []
+
+  public var filteredCounts: [ReviewCounts] {
+    var filtered: [ReviewCounts] = [], new = 0
+    for reviewCount in counts {
+      new += reviewCount.new
+      print(reviewCount.date.hour)
+      if DailyReviews.hours.contains(reviewCount.date.hour) {
+        filtered.append(ReviewCounts(date: reviewCount.date, total: reviewCount.total, new: new))
+        new = 0
+      }
+    }
+    print(filtered)
+    return filtered
+  }
+
+  public var dayOfWeek: String { counts.first?.date.dayOfWeek ?? "" }
+  public var total: Int { counts.last?.total ?? 0 }
+  public var initialTotal: Int { (counts.first?.total ?? 0) - (counts.first?.new ?? 0) }
+  public var new: Int { total - initialTotal }
+
+  public mutating func append(_ counts: ReviewCounts) { self.counts.append(counts) }
+
+  init(counts: [ReviewCounts]) { self.counts = counts }
+}
+
+public extension Date {
+  var hour: Int {
+    Calendar.current.dateComponents([.hour], from: self).hour!
+  }
+
+  var hourTruncated: Date? {
+    Calendar.current.date(bySettingHour: hour, minute: 0, second: 0, of: self)
+  }
+
+  var dayOfWeek: String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "EEE"
+    return dateFormatter.string(from: self).capitalized
+  }
+
+  var timeString: String {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .none
+    formatter.timeStyle = .short
+    return formatter.string(from: self)
+  }
+
+  var dateString: String {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .full
+    formatter.timeStyle = .none
+    return formatter.string(from: self)
+  }
+}
+
+// MARK: - Data access
+
+public enum AppGroup {
+  static let bundle = (Bundle.main.infoDictionary!["CFBundleIdentifier"] as! String)
+    .split(separator: ".")[0 ... 2].joined(separator: ".")
+  static let wanikani = "group.\(bundle)"
+  static let widget = "\(bundle).widget"
+
+  static let containerURL =
+    FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: wanikani)!
+
+  static let dataURL = containerURL.appendingPathComponent("WidgetData.plist")
+
+  @available(iOS 14.0, iOSApplicationExtension 14.0, macCatalyst 14.0, *)
+  public static func reloadTimeline() {
+    #if canImport(WidgetKit) && (arch(arm64) || arch(i386) || arch(x86_64))
+      WidgetCenter.shared.reloadAllTimelines()
+      print("Reloaded timeline!")
+    #endif
+  }
+
+  public static func readGroupData() -> ExpandedWidgetData {
+    var d: CodedWidgetData
+    if let data = try? Data(contentsOf: dataURL),
+       let decodedData = try? PropertyListDecoder().decode(CodedWidgetData.self, from: data) {
+      d = decodedData
+    } else {
+      d = CodedWidgetData(sampleData: true)
+    }
+    return ExpandedWidgetData(date: d.date, lessons: d.lessons,
+                              reviewForecast: ReviewCounts.projectedReviews(from: d))
+  }
+
+  public static func writeGroupData(_ lessons: Int, _ reviews: Int, _ reviewForecast: [Int]) {
+    let data = CodedWidgetData(lessons: lessons, reviews: reviews, reviewForecast: reviewForecast,
+                               date: Date().hourTruncated!)
+    let encoder = PropertyListEncoder()
+    try! encoder.encode(data).write(to: dataURL)
+    if #available(iOS 14.0, iOSApplicationExtension 14.0, macCatalyst 14.0, *) { reloadTimeline() }
+  }
+}

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -167,6 +167,7 @@ class MainViewController: UITableViewController, LoginViewControllerDelegate,
     let currentLevelAssignments = services.localCachingClient.getAssignmentsAtUsersCurrentLevel()
 
     let model = MutableTableModel(tableView: tableView)
+    AppGroup.writeGroupData(lessons, reviews, upcomingReviews)
 
     if !user.hasVacationStartedAt {
       model.add(section: "Currently available")

--- a/ios/Resources/Tsurukame.entitlements
+++ b/ios/Resources/Tsurukame.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.davidsansome.wanikani</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -1757,7 +1757,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.davidsansome.wk.Tests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.davidsansome.wanikani.Tests;
 				PRODUCT_MODULE_NAME = Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tsurukame-Bridging-Header.h";
@@ -1785,7 +1785,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.davidsansome.wk.Tests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.davidsansome.wanikani.Tests;
 				PRODUCT_MODULE_NAME = Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tsurukame-Bridging-Header.h";

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		482D7C0F261CC29900104F69 /* ApprenticeLimitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482D7C0E261CC29900104F69 /* ApprenticeLimitViewController.swift */; };
 		483EBFDC261DD7190043C804 /* FontScreenshotterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4874562D261DD28E00F33AA3 /* FontScreenshotterUITests.swift */; };
 		48CF714823EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 48CF714623EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m */; };
+		48D8B59D2526A17B000470EE /* AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D8B48C252660B9000470EE /* AppGroup.swift */; };
 		48F4B1DC268CB9850033860E /* UpcomingReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F4B1DB268CB9850033860E /* UpcomingReviewsViewController.swift */; };
 		5C82B2908507339A293B0E59 /* Pods_FontScreenshotter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F33812F134DC80E5D981C40E /* Pods_FontScreenshotter.framework */; };
 		630ADB6F21F8256E00BC9801 /* TKMCheckmarkModelItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 630ADB6E21F8256E00BC9801 /* TKMCheckmarkModelItem.m */; };
@@ -228,6 +229,7 @@
 		4874562E261DD28E00F33AA3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		489894D423670CB000A20AF8 /* Tsurukame.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tsurukame.entitlements; sourceTree = "<group>"; };
 		48CF714623EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TKMReviewBatchSizeViewController.m; sourceTree = "<group>"; };
+		48D8B48C252660B9000470EE /* AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroup.swift; sourceTree = "<group>"; };
 		48F4B1DB268CB9850033860E /* UpcomingReviewsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpcomingReviewsViewController.swift; sourceTree = "<group>"; };
 		4B8236EC341CF1BA18D16857 /* Pods-Tsurukame-Tsurukame Complication Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tsurukame-Tsurukame Complication Extension.release.xcconfig"; path = "Target Support Files/Pods-Tsurukame-Tsurukame Complication Extension/Pods-Tsurukame-Tsurukame Complication Extension.release.xcconfig"; sourceTree = "<group>"; };
 		630ADB6D21F8256E00BC9801 /* TKMCheckmarkModelItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TKMCheckmarkModelItem.h; sourceTree = "<group>"; };
@@ -499,6 +501,7 @@
 				C904455C2395DBAE001BC48B /* AnswerTextField.swift */,
 				638A5C4D25A471F9001A7AEE /* AppDelegate.swift */,
 				482D7C0E261CC29900104F69 /* ApprenticeLimitViewController.swift */,
+				48D8B48C252660B9000470EE /* AppGroup.swift */,
 				6335B46323CF0C820071671E /* AppStoreScreenshots */,
 				6335B46223CF0C820071671E /* AppStoreScreenshots.xctest */,
 				63F7F52D23D4C2CA006A31FB /* Audio.swift */,
@@ -1219,6 +1222,7 @@
 				63F7F51F23D3F335006A31FB /* ReadingModelItem.swift in Sources */,
 				633DE9322094D22800AC25F4 /* ReviewOrderViewController.m in Sources */,
 				633AFAE62352B6F2004F732F /* VocabularyHighlighter.swift in Sources */,
+				48D8B59D2526A17B000470EE /* AppGroup.swift in Sources */,
 				631CAD63234AD5FC008CEA73 /* AnswerChecker.swift in Sources */,
 				63C74C6825C96088004F6C99 /* SubjectChip.swift in Sources */,
 				482D7C0F261CC29900104F69 /* ApprenticeLimitViewController.swift in Sources */,


### PR DESCRIPTION
This PR adds the App Groups capability & functionality as previously discussed in PR #270, because it's required for PR #413.

Consequently, upon merging this PR, you may need to make a change in App Store Connect to add the App Groups capability on that side of the app.