### PR TITLE
Enable App Group capability

### DIFF
--- a/ios/Resources/Tsurukame.entitlements
+++ b/ios/Resources/Tsurukame.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.davidsansome.wanikani</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>


### PR DESCRIPTION
This PR simply enables the app group capability, a requirement for future PRs such as for a widget.

If App Groups aren't enabled for your provisioning profile in App Store Connect, you'll need to do so.