### PR TITLE
Fix lack of configurability for review item type sorting

### DIFF
--- a/ios/LessonOrderViewController.swift
+++ b/ios/LessonOrderViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2021 David Sansome
+// Copyright 2022 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,20 +16,34 @@ import Foundation
 import WaniKaniAPI
 
 class LessonOrderViewController: UITableViewController {
+  var hasLessonOrder: Bool!
+  var typeOrder: [TKMSubject.TypeEnum] {
+    get { hasLessonOrder ? Settings.lessonOrder : Settings.reviewTypeOrder }
+    set {
+      if hasLessonOrder { Settings.lessonOrder = newValue }
+      else { Settings.reviewTypeOrder = newValue }
+    }
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    hasLessonOrder = true
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
     tableView.isEditing = true
   }
 
   override func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
-    Settings.lessonOrder.count
+    typeOrder.count
   }
 
   override func tableView(_ tableView: UITableView,
                           cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cell = (tableView.dequeueReusableCell(withIdentifier: "cell") as? LessonOrderCell) ??
       LessonOrderCell(style: .default, reuseIdentifier: "cell")
-    cell.subjectType = Settings.lessonOrder[indexPath.row]
+    cell.subjectType = typeOrder[indexPath.row]
     return cell
   }
 
@@ -46,10 +60,10 @@ class LessonOrderViewController: UITableViewController {
                           to destinationIndexPath: IndexPath) {
     let cell = tableView.cellForRow(at: sourceIndexPath) as! LessonOrderCell
 
-    var lessonOrder = Settings.lessonOrder
+    var lessonOrder = typeOrder
     lessonOrder.remove(at: sourceIndexPath.row)
     lessonOrder.insert(cell.subjectType, at: destinationIndexPath.row)
-    Settings.lessonOrder = lessonOrder
+    typeOrder = lessonOrder
   }
 }
 

--- a/ios/Resources/Settings.storyboard
+++ b/ios/Resources/Settings.storyboard
@@ -1126,6 +1126,7 @@
                     <connections>
                         <segue destination="7Tc-3C-9Vx" kind="show" identifier="taskOrder" id="ciw-Ib-lXD"/>
                         <segue destination="uj2-VH-hcW" kind="show" identifier="reviewOrder" id="aCJ-db-gAl"/>
+                        <segue destination="Eh2-Gf-xh0" kind="show" identifier="reviewTypeOrder" id="gQR-Z8-EnR"/>
                         <segue destination="AG2-Tf-RDu" kind="show" identifier="offlineAudio" id="vTO-IO-L6z"/>
                         <segue destination="QeO-rY-q75" kind="show" identifier="fonts" id="8GM-bp-oBp"/>
                         <segue destination="QeO-rY-q01" kind="show" identifier="fontSize" id="exa-yV-rae"/>
@@ -1178,6 +1179,82 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yiz-GX-A7J" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1113" y="772"/>
+        </scene>
+        <!--Review type order-->
+        <scene sceneID="oLF-Gq-9bR">
+            <objects>
+                <tableViewController title="Review type order" id="Eh2-Gf-xh0" customClass="ReviewTypeOrderViewController" customModule="Tsurukame" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="4bb-Ge-02b">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <sections>
+                            <tableViewSection id="OY9-xp-bcU">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="10" textLabel="Mu6-Ng-aAr" style="IBUITableViewCellStyleDefault" id="PJT-yT-d7d">
+                                        <rect key="frame" x="20" y="18" width="374" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PJT-yT-d7d" id="J5N-c6-hea">
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Radicals" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Mu6-Ng-aAr">
+                                                    <rect key="frame" x="20" y="0.0" width="334" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="10" textLabel="VXs-cg-kLL" style="IBUITableViewCellStyleDefault" id="yP1-lK-cge">
+                                        <rect key="frame" x="20" y="61.5" width="374" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yP1-lK-cge" id="Pu2-pp-ZuD">
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Kanji" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="VXs-cg-kLL">
+                                                    <rect key="frame" x="20" y="0.0" width="334" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="blue" indentationWidth="10" textLabel="zEz-eE-9fh" style="IBUITableViewCellStyleDefault" id="gy3-SS-z37">
+                                        <rect key="frame" x="20" y="105" width="374" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gy3-SS-z37" id="wO9-Vl-CzJ">
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Vocabulary" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zEz-eE-9fh">
+                                                    <rect key="frame" x="20" y="0.0" width="334" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="Eh2-Gf-xh0" id="Nfg-nF-K1d"/>
+                            <outlet property="delegate" destination="Eh2-Gf-xh0" id="LHI-oh-mAH"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Review Type Order" id="61p-5H-3dj"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Q9K-76-dmu" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4388" y="-648"/>
         </scene>
     </scenes>
     <resources>

--- a/ios/ReviewSettingsViewController.swift
+++ b/ios/ReviewSettingsViewController.swift
@@ -47,6 +47,12 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
                              accessoryType: .disclosureIndicator,
                              target: self,
                              action: #selector(didTapReviewOrder(_:))))
+    model.add(BasicModelItem(style: .value1,
+                             title: "Type order",
+                             subtitle: reviewTypeOrderValueText,
+                             accessoryType: .disclosureIndicator,
+                             target: self,
+                             action: #selector(didTapReviewTypeOrder(_:))))
     model.add(SwitchModelItem(style: .subtitle,
                               title: "Back-to-back",
                               subtitle: "Group Meaning and Reading together",
@@ -205,6 +211,14 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
     Settings.reviewOrder.description
   }
 
+  private var reviewTypeOrderValueText: String {
+    var parts = [String]()
+    for subjectType in Settings.reviewTypeOrder {
+      parts.append(subjectType.description)
+    }
+    return parts.joined(separator: ", ")
+  }
+
   private var taskOrderValueText: String {
     Settings.meaningFirst ? "Meaning first" : "Reading first"
   }
@@ -301,6 +315,10 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
 
   @objc private func didTapReviewOrder(_: BasicModelItem) {
     performSegue(withIdentifier: "reviewOrder", sender: self)
+  }
+
+  @objc private func didTapReviewTypeOrder(_: BasicModelItem) {
+    performSegue(withIdentifier: "reviewTypeOrder", sender: self)
   }
 
   @objc private func didTapFonts(_: BasicModelItem) {

--- a/ios/ReviewTypeOrderViewController.swift
+++ b/ios/ReviewTypeOrderViewController.swift
@@ -1,0 +1,22 @@
+// Copyright 2022 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+class ReviewTypeOrderViewController: LessonOrderViewController {
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    hasLessonOrder = false
+  }
+}

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -254,56 +254,49 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
       reviewQueue.sort { (a, b: ReviewItem) -> Bool in
         if a.assignment.srsStage < b.assignment.srsStage { return true }
         if a.assignment.srsStage > b.assignment.srsStage { return false }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+        if let sort = sortTypeOrder(a, b) { return sort }
         return false
       }
     case .descendingSRSStage:
       reviewQueue.sort { (a, b: ReviewItem) -> Bool in
         if a.assignment.srsStage < b.assignment.srsStage { return false }
         if a.assignment.srsStage > b.assignment.srsStage { return true }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+        if let sort = sortTypeOrder(a, b) { return sort }
         return false
       }
     case .currentLevelFirst:
       reviewQueue.sort { (a, b: ReviewItem) -> Bool in
         if a.assignment.level < b.assignment.level { return false }
         if a.assignment.level > b.assignment.level { return true }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+        if let sort = sortTypeOrder(a, b) { return sort }
         return false
       }
     case .lowestLevelFirst:
       reviewQueue.sort { (a, b: ReviewItem) -> Bool in
         if a.assignment.level < b.assignment.level { return true }
         if a.assignment.level > b.assignment.level { return false }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+        if let sort = sortTypeOrder(a, b) { return sort }
         return false
       }
     case .newestAvailableFirst:
       reviewQueue.sort { (a, b: ReviewItem) -> Bool in
         if a.assignment.availableAt < b.assignment.availableAt { return false }
         if a.assignment.availableAt > b.assignment.availableAt { return true }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+        if let sort = sortTypeOrder(a, b) { return sort }
         return false
       }
     case .oldestAvailableFirst:
       reviewQueue.sort { (a, b: ReviewItem) -> Bool in
         if a.assignment.availableAt < b.assignment.availableAt { return true }
         if a.assignment.availableAt > b.assignment.availableAt { return false }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+        if let sort = sortTypeOrder(a, b) { return sort }
         return false
       }
     case .longestRelativeWait:
       reviewQueue.sort { (a, b: ReviewItem) -> Bool in
         if availableRatio(a.assignment) < availableRatio(b.assignment) { return false }
         if availableRatio(a.assignment) > availableRatio(b.assignment) { return true }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+        if let sort = sortTypeOrder(a, b) { return sort }
         return false
       }
     case .random:
@@ -314,6 +307,14 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     }
 
     refillActiveQueue()
+  }
+
+  private func sortTypeOrder(_ a: ReviewItem, _ b: ReviewItem) -> Bool? {
+    let aIndex = Settings.reviewTypeOrder.firstIndex(of: a.assignment.subjectType)!
+    let bIndex = Settings.reviewTypeOrder.firstIndex(of: b.assignment.subjectType)!
+    if aIndex < bIndex { return true }
+    else if aIndex > bIndex { return false }
+    else { return nil }
   }
 
   private func availableRatio(_ assignment: TKMAssignment) -> TimeInterval {

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -160,6 +160,11 @@ private func getArchiveData<T: Codable>(_ defaultValue: T, key: String) -> T {
   @Setting(true, #keyPath(showStatsSection)) static var showStatsSection: Bool
 
   @EnumSetting(ReviewOrder.random, #keyPath(reviewOrder)) static var reviewOrder: ReviewOrder
+  @EnumArraySetting([
+    .radical,
+    .kanji,
+    .vocabulary,
+  ], "reviewTypeOrder") static var reviewTypeOrder: [TKMSubject.TypeEnum]
   @Setting(5, #keyPath(reviewBatchSize)) static var reviewBatchSize: Int
   @Setting(Int.max, #keyPath(apprenticeLessonsLimit)) static var apprenticeLessonsLimit: Int
   @Setting(false, #keyPath(groupMeaningReading)) static var groupMeaningReading: Bool

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		4820306724D849E100B40FDD /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633632EE201F3490006D582B /* Settings.swift */; };
 		482D7C0F261CC29900104F69 /* ApprenticeLimitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482D7C0E261CC29900104F69 /* ApprenticeLimitViewController.swift */; };
 		483EBFDC261DD7190043C804 /* FontScreenshotterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4874562D261DD28E00F33AA3 /* FontScreenshotterUITests.swift */; };
+		486823FA27B88EF90035D7AB /* ReviewTypeOrderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486823F927B88EF90035D7AB /* ReviewTypeOrderViewController.swift */; };
 		48CF714823EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 48CF714623EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m */; };
 		48F4B1DC268CB9850033860E /* UpcomingReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F4B1DB268CB9850033860E /* UpcomingReviewsViewController.swift */; };
 		5C82B2908507339A293B0E59 /* Pods_FontScreenshotter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F33812F134DC80E5D981C40E /* Pods_FontScreenshotter.framework */; };
@@ -231,6 +232,7 @@
 		481B2FEC23C55AAF0041EF1F /* CurrentLevelReviewTimeItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrentLevelReviewTimeItem.swift; sourceTree = "<group>"; };
 		4826740B23ECE46900F704E4 /* TKMReviewBatchSizeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TKMReviewBatchSizeViewController.h; sourceTree = "<group>"; };
 		482D7C0E261CC29900104F69 /* ApprenticeLimitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApprenticeLimitViewController.swift; sourceTree = "<group>"; };
+		486823F927B88EF90035D7AB /* ReviewTypeOrderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTypeOrderViewController.swift; sourceTree = "<group>"; };
 		4874562D261DD28E00F33AA3 /* FontScreenshotterUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontScreenshotterUITests.swift; sourceTree = "<group>"; };
 		4874562E261DD28E00F33AA3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		489894D423670CB000A20AF8 /* Tsurukame.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tsurukame.entitlements; sourceTree = "<group>"; };
@@ -556,6 +558,7 @@
 				637CA12B25D7EDFE0082580E /* ReviewSummaryViewController.swift */,
 				633DE9332094D80D00AC25F4 /* ReviewTaskOrderViewController.h */,
 				633DE9342094D80D00AC25F4 /* ReviewTaskOrderViewController.m */,
+				486823F927B88EF90035D7AB /* ReviewTypeOrderViewController.swift */,
 				631CAD71234B4A96008CEA73 /* ReviewViewController.swift */,
 				63BEBF9625C57D4000123147 /* SearchResultViewController.swift */,
 				63F7F52B23D43DF6006A31FB /* Services.swift */,
@@ -1254,6 +1257,7 @@
 				63F7F52523D429A4006A31FB /* String+MD5.swift in Sources */,
 				48CF714823EAFA5600A838F4 /* TKMReviewBatchSizeViewController.m in Sources */,
 				63358EA227366D720013A2AC /* CheckmarkModelItem.swift in Sources */,
+				486823FA27B88EF90035D7AB /* ReviewTypeOrderViewController.swift in Sources */,
 				63391B572779B7FC005CDA72 /* AppSettingsViewController.swift in Sources */,
 				63E9A8D421108FB400418CE1 /* UIView+SafeAreaInsets.m in Sources */,
 				633AFAE123516BE7004F732F /* SubjectDetailsView.swift in Sources */,


### PR DESCRIPTION
When selecting a non-random review order, Tsurukame will automatically apply a secondary sort of radicals, kanji, and vocab, in that order. However, although it is fixed and non-random, users are not able to choose the order of the secondary sort.

This PR fixes #304 by adding an identical mechanism as the lesson order interface for reviews. Consequently, there should be no concerns about lack of quality of this PR. This PR is limited in scope and does not attempt to add any new features.

This PR has been tested and is immediately ready for review.

**This should NOT be a major pull request! There is almost nothing actually new to the codebase here. If there is any problem with this PR, even just that you don't want PRs at the moment, please let me know!**