### PR TITLE
Revert #269 (Fixes #591)

### DIFF
--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -159,13 +159,6 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
         continue
       }
 
-      // Skip assignments that are a higher level than the user's current level. Wanikani items that
-      // have moved to later levels can end up in this state and reviews will not be saved by the WK
-      // API so they end up perpetually reviewed.
-      if user.hasLevel, user.level < assignment.level {
-        continue
-      }
-
       if assignment.isLessonStage {
         lessonCount += 1
       } else if assignment.isReviewStage {

--- a/ios/ReviewItem.swift
+++ b/ios/ReviewItem.swift
@@ -35,7 +35,6 @@ class ReviewItem: NSObject {
 
     for assignment in assignments {
       if !localCachingClient.isValid(subjectId: assignment.subjectID) ||
-        (userInfo.hasLevel && userInfo.level < assignment.level) ||
         !isIncluded(assignment) {
         continue
       }


### PR DESCRIPTION
Due to [WaniKani's recent change](https://community.wanikani.com/t/higher-level-items-in-review-queue/57004), the feature introduced in #269 is now preventing Tsurukame users from performing some of their reviews.

This reverts commit d271ff95641ab63205c7901c1e0086ceaaaf0d56 and fixes #591.