### PR TITLE
Fix main screen section header height on iPad and Mac

### DIFF
--- a/ios/Tables/TableModel.swift
+++ b/ios/Tables/TableModel.swift
@@ -40,6 +40,8 @@ class TableModel: NSObject, UITableViewDataSource, UITableViewDelegate {
     super.init()
     tableView.dataSource = self
     tableView.delegate = self
+
+    tableView.sectionHeaderHeight = 35
   }
 
   convenience init(tableView: UITableView) {

--- a/ios/Tables/TableModel.swift
+++ b/ios/Tables/TableModel.swift
@@ -40,8 +40,7 @@ class TableModel: NSObject, UITableViewDataSource, UITableViewDelegate {
     super.init()
     tableView.dataSource = self
     tableView.delegate = self
-
-    tableView.sectionHeaderHeight = 35
+    fixHeadersOnMac()
   }
 
   convenience init(tableView: UITableView) {
@@ -55,6 +54,16 @@ class TableModel: NSObject, UITableViewDataSource, UITableViewDelegate {
   @objc(itemsInSection:)
   func items(inSection section: Int) -> [TKMModelItem] {
     sections[section].items
+  }
+
+  private func fixHeadersOnMac() {
+    // Ensure macOS can see section header text
+    #if targetEnvironment(macCatalyst)
+      tableView.sectionHeaderHeight = 28
+    #endif
+    if #available(iOS 14.0, *), ProcessInfo.processInfo.isiOSAppOnMac {
+      self.tableView.sectionHeaderHeight = 28
+    }
   }
 
   // MARK: - Hiding items


### PR DESCRIPTION
There's probably a better way to do this, I just don't know it. Somehow the UILabel for the section header has decided that it has zero lines, and so on iPad and Mac the automatic height is getting collapsed down to nothing.

Before this change:

<img width="901" alt="image" src="https://user-images.githubusercontent.com/78/181152633-cb251a5d-490f-44bc-9ca1-ed86e4e77c5a.png">

After this change:

<img width="901" alt="image" src="https://user-images.githubusercontent.com/78/181152648-50074111-ded1-49c1-8e4f-a3fd873bf2e5.png">

Fixes #558.