### PR TITLE
Dismiss review session summary with keyboard

### DIFF
--- a/ios/ReviewSummaryViewController.swift
+++ b/ios/ReviewSummaryViewController.swift
@@ -77,6 +77,19 @@ class ReviewSummaryViewController: UITableViewController, SubjectDelegate {
     navigationController?.popToRootViewController(animated: true)
   }
 
+  override var canBecomeFirstResponder: Bool {
+    true
+  }
+
+  override var keyCommands: [UIKeyCommand]? {
+    [
+      UIKeyCommand(input: "\r",
+                   modifierFlags: [],
+                   action: #selector(doneClicked),
+                   discoverabilityTitle: "Dismiss review session results"),
+    ]
+  }
+
   // MARK: - SubjectDelegate
 
   func didTapSubject(_ subject: TKMSubject) {


### PR DESCRIPTION
Adds a keyboard shortcut 
(Return / ↩) to dismiss the review summary screen and return to the main screen. This makes it possible to review and then move on to lessons (or more reviews, if they have come up) from the keyboard.

Fixes #559.