### PR TITLE
Keep keyboard focus, even after wrong answers

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -902,14 +902,8 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
   func textFieldShouldReturn(_: UITextField) -> Bool {
     enterKeyPressed()
 
-    // Keep the cursor in the text field on OtherKanjiReading or ContainsInvalidCharacters
-    // AnswerCheckerResult cases except when subject details are displayed.
-    if subjectDetailsView.isHidden,
-       session.activeTask.answer.hasMeaningWrong || session.activeTask.answer.hasReadingWrong {
-      return false
-    }
-
-    return true
+    // Keep the cursor in the text field except when subject details are displayed.
+    return !subjectDetailsView.isHidden
   }
 
   @objc func enterKeyPressed() {


### PR DESCRIPTION
Keeps keyboard focus on the input field after pressing "return" at times when focus was previously lost, including when the input is empty, or when the answer is wrong. With this patch applied, it becomes possible to miss a review, read the subject details, and still be able to press return again to continue. It also preserves focus in the cases where the answer was neither right nor wrong and produced a screen shake.

Tested on iPhone, iPad, macOS (Designed for iPad), and macOS (Catalyst). Seems to work!

Fixes #560