### PR TITLE
fix section header clipping the right way

### DIFF
--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Whd-2S-WNr">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Whd-2S-WNr">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -153,7 +153,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="I7j-0Z-n8n">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="I7j-0Z-n8n">
                                 <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <sections/>

--- a/ios/Tables/TableModel.swift
+++ b/ios/Tables/TableModel.swift
@@ -40,7 +40,6 @@ class TableModel: NSObject, UITableViewDataSource, UITableViewDelegate {
     super.init()
     tableView.dataSource = self
     tableView.delegate = self
-    fixHeadersOnMac()
   }
 
   convenience init(tableView: UITableView) {
@@ -54,16 +53,6 @@ class TableModel: NSObject, UITableViewDataSource, UITableViewDelegate {
   @objc(itemsInSection:)
   func items(inSection section: Int) -> [TKMModelItem] {
     sections[section].items
-  }
-
-  private func fixHeadersOnMac() {
-    // Ensure macOS can see section header text
-    #if targetEnvironment(macCatalyst)
-      tableView.sectionHeaderHeight = 28
-    #endif
-    if #available(iOS 14.0, *), ProcessInfo.processInfo.isiOSAppOnMac {
-      self.tableView.sectionHeaderHeight = 28
-    }
   }
 
   // MARK: - Hiding items


### PR DESCRIPTION
thanks to a friend at apple, it was pointed out to me that the storyboard xib had hardcoded section heights, apparently originally due to a long-ago bug in xcode. removing the incorrect hardcoded heights from the xib means my weird hack-around isn't needed anymore! phew.