### PR TITLE
remove keyboard inset hack, unglitch iPhone 14 Pro

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -183,7 +183,6 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
   // These are set to match the keyboard animation.
   private var animationDuration: Double = kDefaultAnimationDuration
   private var animationCurve: UIView.AnimationCurve = kDefaultAnimationCurve
-  private var previousKeyboardInsetHeight: CGFloat?
 
   private var currentFontName: String!
   private var normalFontName: String!
@@ -395,17 +394,6 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     let insetHeight = max(0, CGFloat(height) - distanceFromViewBottomToWindowBottom)
 
     answerFieldToBottomConstraint.constant = insetHeight
-
-    // When the keyboard changes size by a small amount (the autocorrect bar is shown/hidden) try
-    // to avoid moving the question label by offsetting its bottom constraint by the same amount the
-    // keyboard moved.
-    if let previousKeyboardInsetHeight = previousKeyboardInsetHeight,
-       abs(insetHeight - previousKeyboardInsetHeight) <= kSmallKeyboardHeightChange {
-      questionLabelBottomConstraint.constant = previousKeyboardInsetHeight - insetHeight
-    } else {
-      questionLabelBottomConstraint.constant = 0
-      previousKeyboardInsetHeight = insetHeight
-    }
 
     var subjectDetailsViewInset = subjectDetailsView.contentInset
     subjectDetailsViewInset.bottom = insetHeight


### PR DESCRIPTION
As seen in screenshots on #587, the UITextField for the answer sometimes seems to move itself down without adjusting the color gradient above it or the lesson view below it. in my testing, this seems to happen when switching between english and japanese keyboards automatically, which sometimes (but not always) triggers the inset hack. After the inset hack has triggered, the heights seem to be wrong.

I'm not sure why this seems to trigger so much more often on iPhone 14 Pro, and not before, but deleting the inset hack seems to resolve this issue, in my testing on a physical iPhone 14 Pro.

Video captured from build equivalent to ad3b00857aba42cd3cb9e4cb4945410bd3d01a52, with reproducible glitch:

https://user-images.githubusercontent.com/78/191701479-6654fce2-d2a8-435e-8ed4-fa4e23c57ce4.mp4


Video captured from build equivalent to f00d0c467bab72a6424faf1d357909cdd680ae18, no more glitch:

https://user-images.githubusercontent.com/78/191701566-23438a7c-e43b-4651-a46c-32ea9642b0bd.mp4


fixes #587 (I hope)