### PR TITLE
match WaniKani keyboard shortcuts in details pane

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1168,8 +1168,8 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
       // Key commands when showing the detail view
       keyCommands.append(contentsOf: [UIKeyCommand(input: " ",
                                                    modifierFlags: [],
-                                                   action: #selector(playAudio),
-                                                   discoverabilityTitle: "Play reading"),
+                                                   action: #selector(showAllInformation),
+                                                   discoverabilityTitle: "Show all information"),
                                       UIKeyCommand(input: "j", modifierFlags: [],
                                                    action: #selector(playAudio)),
                                       UIKeyCommand(input: "a",
@@ -1196,6 +1196,12 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
                                                    discoverabilityTitle: "Add as synonym"),
                                       keyboardEnter,
                                       numericKeyPadEnter])
+    } else {
+      if !revealAnswerButton.isHidden {
+        keyCommands.append(UIKeyCommand(action: #selector(revealAnswerButtonPressed),
+                                        input: "f",
+                                        discoverabilityTitle: "Reveal answer"))
+      }
     }
 
     if Settings.selectedFonts.count > 0 {
@@ -1219,6 +1225,12 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
                                       discoverabilityTitle: "Previous subject"))
     }
     return keyCommands
+  }
+
+  @objc func showAllInformation() {
+    if !subjectDetailsView.isHidden {
+      subjectDetailsView.showAllFields()
+    }
   }
 
   @objc func playAudio() {

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1198,8 +1198,9 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
                                       numericKeyPadEnter])
     } else {
       if !revealAnswerButton.isHidden {
-        keyCommands.append(UIKeyCommand(action: #selector(revealAnswerButtonPressed),
-                                        input: "f",
+        keyCommands.append(UIKeyCommand(input: "f",
+                                        modifierFlags: [],
+                                        action: #selector(revealAnswerButtonPressed),
                                         discoverabilityTitle: "Reveal answer"))
       }
     }

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -269,7 +269,7 @@ class SubjectDetailsView: UITableView, SubjectChipDelegate {
 
   static var showAllFieldsCount = 0
 
-  @objc private func showAllFields() {
+  @objc func showAllFields() {
     update(withSubject: subject, studyMaterials: studyMaterials, assignment: assignment, task: nil)
 
     // If the user keeps pressing the button, prompt them once to enable the showFullAnswer setting.

--- a/ios/SubjectDetailsViewController.swift
+++ b/ios/SubjectDetailsViewController.swift
@@ -121,15 +121,20 @@ class SubjectDetailsViewController: UIViewController, SubjectDelegate, TKMViewCo
   override var canBecomeFirstResponder: Bool { true }
   override var keyCommands: [UIKeyCommand]? {
     [
-      UIKeyCommand(input: " ",
-                   modifierFlags: [],
-                   action: #selector(playAudio),
+      UIKeyCommand(action: #selector(showAllInformation),
+                   input: " ",
+                   discoverabilityTitle: "Show all information"),
+      UIKeyCommand(action: #selector(playAudio),
+                   input: "j",
                    discoverabilityTitle: "Play reading"),
-      UIKeyCommand(input: UIKeyCommand.inputLeftArrow,
-                   modifierFlags: [],
-                   action: #selector(backButtonPressed),
+      UIKeyCommand(action: #selector(backButtonPressed),
+                   input: UIKeyCommand.inputLeftArrow,
                    discoverabilityTitle: "Back"),
     ]
+  }
+
+  @objc func showAllInformation() {
+    subjectDetailsView.showAllFields()
   }
 
   @objc func playAudio() {

--- a/ios/SubjectDetailsViewController.swift
+++ b/ios/SubjectDetailsViewController.swift
@@ -121,14 +121,17 @@ class SubjectDetailsViewController: UIViewController, SubjectDelegate, TKMViewCo
   override var canBecomeFirstResponder: Bool { true }
   override var keyCommands: [UIKeyCommand]? {
     [
-      UIKeyCommand(action: #selector(showAllInformation),
-                   input: " ",
+      UIKeyCommand(input: " ",
+                   modifierFlags: [],
+                   action: #selector(showAllInformation),
                    discoverabilityTitle: "Show all information"),
-      UIKeyCommand(action: #selector(playAudio),
-                   input: "j",
+      UIKeyCommand(input: "j",
+                   modifierFlags: [],
+                   action: #selector(playAudio),
                    discoverabilityTitle: "Play reading"),
-      UIKeyCommand(action: #selector(backButtonPressed),
-                   input: UIKeyCommand.inputLeftArrow,
+      UIKeyCommand(input: UIKeyCommand.inputLeftArrow,
+                   modifierFlags: [],
+                   action: #selector(backButtonPressed),
                    discoverabilityTitle: "Back"),
     ]
   }


### PR DESCRIPTION
after missing a reading, WaniKani shows the correct reading, but hides the meaning and the mnemonics. there is [a keyboard shortcut][1] to show the hidden information: spacebar.

This can (sometimes) conflict with an existing keyboard shortcut to play the audio reading for a vocabulary word. I have tried to preserve that behavior everywhere possible, and only take over the shortcut when there is hidden information to show.

This commit makes Tsurukame match the WaniKani website shortcuts "f" (to show details after an incorrect answer), "spacebar" (to show the hidden full information while viewing details), and "j" (to play the audio recording of a vocabulary word while viewing details).

[1]: https://knowledge.wanikani.com/wanikani/keyboard-shortcuts/