### PR TITLE
Account for resets when estimating level time

### DIFF
--- a/ios/LevelTimeRemainingItem.swift
+++ b/ios/LevelTimeRemainingItem.swift
@@ -88,7 +88,9 @@ private func calculateLevelTimeRemaining(services: TKMServices,
 private func averageRemainingLevelTime(_ lcc: LocalCachingClient) -> TimeInterval {
   var timeSpentAtEachLevel = [TimeInterval]()
   for level in lcc.getAllLevelProgressions() {
-    timeSpentAtEachLevel.append(level.timeSpentCurrent)
+    if level.timeSpentCurrent > 0 {
+      timeSpentAtEachLevel.append(level.timeSpentCurrent)
+    }
   }
   if timeSpentAtEachLevel.isEmpty {
     return 0

--- a/ios/WaniKaniAPI/Sources/WaniKaniAPI/ProtobufExtensions.swift
+++ b/ios/WaniKaniAPI/Sources/WaniKaniAPI/ProtobufExtensions.swift
@@ -398,7 +398,7 @@ public extension TKMLevel {
   var createdAtDate: Date { Date(timeIntervalSince1970: TimeInterval(createdAt)) }
 
   var timeSpentCurrent: TimeInterval {
-    if !hasUnlockedAt {
+    if !hasUnlockedAt || hasAbandonedAt {
       return 0
     }
     let startDate = hasStartedAt ? startedAtDate : unlockedAtDate


### PR DESCRIPTION
When a Wanikani user resets to a lower level, the level they were on when they reset never gets a `completedAt`, it gets `abandonedAt` instead. That means we have been including the entire time from the moment each abandoned/reset level was started until the present moment in the average calculation—for me personally, that meant the estimated level times were around 90 days. Excluding level time records that have an abandonedAt present fixes the estimation. While reviewing the calculation, I noticed that we were sometimes including zeroes in the list of level times, so I added a check to remove those.

Before: Estimated level time 90d
After: Estimated level time 10d

Since I have never taken 90 days to complete a level, and usually take about 10 days, it seems like that fixed it.