### PR TITLE
Allow API token login

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -45,7 +45,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, LoginViewControllerDelega
     let nc = NotificationCenter.default
     nc.addObserver(self, selector: #selector(logout), name: .logout, object: nil)
 
-    if !Settings.userApiToken.isEmpty, !Settings.userCookie.isEmpty {
+    if !Settings.userApiToken.isEmpty {
       setMainViewControllerAnimated(animated: false, clearUserData: false)
     } else {
       pushLoginViewController()
@@ -132,7 +132,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, LoginViewControllerDelega
 
   @objc
   private func logout(_: Notification?) {
-    Settings.userCookie = ""
     Settings.userApiToken = ""
     Settings.userEmailAddress = ""
     services.localCachingClient.clearAllDataAndClose()

--- a/ios/AppStoreScreenshots/Screenshotter.swift
+++ b/ios/AppStoreScreenshots/Screenshotter.swift
@@ -47,12 +47,10 @@ import WaniKaniAPI
       if isActive {
         if ProcessInfo.processInfo.arguments.contains("ResetUserDefaults") {
           // We're run again after testing finishes to remove the dummy user.
-          Settings.userCookie = ""
           Settings.userApiToken = ""
           Settings.userEmailAddress = ""
         } else {
           // Pretend there's a logged in user.
-          Settings.userCookie = "dummy"
           Settings.userApiToken = "dummy"
           Settings.userEmailAddress = "dummy"
           Settings.showSRSLevelIndicator = true

--- a/ios/LoginViewController.swift
+++ b/ios/LoginViewController.swift
@@ -36,6 +36,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
   @IBOutlet private var signInButton: UIButton!
   @IBOutlet private var apiTokenField: UITextField!
   @IBOutlet private var signInWithAPITokenButton: UIButton!
+  @IBOutlet private var swapLoginMethodsButton: UIButton!
   @IBOutlet private var privacyPolicyLabel: UILabel!
   @IBOutlet private var privacyPolicyButton: UIButton!
   @IBOutlet private var activityIndicatorOverlay: UIView!
@@ -47,6 +48,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     TKMStyle.addShadowToView(signInLabel, offset: 0, opacity: 1, radius: 5)
     TKMStyle.addShadowToView(privacyPolicyLabel, offset: 0, opacity: 1, radius: 2)
     TKMStyle.addShadowToView(privacyPolicyButton, offset: 0, opacity: 1, radius: 2)
+    TKMStyle.addShadowToView(swapLoginMethodsButton, offset: 0, opacity: 1, radius: 2)
 
     if let forcedUsername = forcedUsername {
       usernameField.text = forcedUsername
@@ -130,6 +132,30 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
       self.delegate?.loginComplete()
     }.catch { _ in
       self.showLoginError("Invalid API token!")
+    }
+  }
+
+  @IBAction func didTapSwapLoginMethods() {
+    UIView.animate(withDuration: 0.1,
+                   delay: 0.0,
+                   options: [.curveLinear],
+                   animations: {
+                     let animatingInUserPass = self.usernameField.isHidden
+                     self.usernameField.isHidden = !animatingInUserPass
+                     self.passwordField.isHidden = !animatingInUserPass
+                     self.signInButton.isHidden = !animatingInUserPass
+
+                     self.apiTokenField.isHidden = animatingInUserPass
+                     self.signInWithAPITokenButton.isHidden = animatingInUserPass
+
+                     self.usernameField.alpha = animatingInUserPass ? 1 : 0
+                     self.passwordField.alpha = animatingInUserPass ? 1 : 0
+                     self.signInButton.alpha = animatingInUserPass ? 1 : 0
+                     self.apiTokenField.alpha = animatingInUserPass ? 0 : 1
+                     self.signInWithAPITokenButton.alpha = animatingInUserPass ? 0 : 1
+                   }) { _ in
+      let title = self.usernameField.isHidden ? "Use username and password" : "Use API token"
+      self.swapLoginMethodsButton.setTitle(title, for: .normal)
     }
   }
 

--- a/ios/LoginViewController.swift
+++ b/ios/LoginViewController.swift
@@ -34,8 +34,8 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
   @IBOutlet private var usernameField: UITextField!
   @IBOutlet private var passwordField: UITextField!
   @IBOutlet private var signInButton: UIButton!
-  @IBOutlet private var apiKeyField: UITextField!
-  @IBOutlet private var signInWithAPIKeyButton: UIButton!
+  @IBOutlet private var apiTokenField: UITextField!
+  @IBOutlet private var signInWithAPITokenButton: UIButton!
   @IBOutlet private var privacyPolicyLabel: UILabel!
   @IBOutlet private var privacyPolicyButton: UIButton!
   @IBOutlet private var activityIndicatorOverlay: UIView!
@@ -55,11 +55,11 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
 
     usernameField.delegate = self
     passwordField.delegate = self
-    apiKeyField.delegate = self
+    apiTokenField.delegate = self
 
     usernameField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
     passwordField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
-    apiKeyField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+    apiTokenField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
     textFieldDidChange(usernameField)
   }
 
@@ -75,7 +75,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
       passwordField.becomeFirstResponder()
     } else if textField == passwordField {
       didTapSignInButton()
-    } else if textField == apiKeyField {
+    } else if textField == apiTokenField {
       didTapSignInWithAPIButton()
     }
     return true
@@ -86,9 +86,9 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     signInButton.isEnabled = enabled
     signInButton.backgroundColor = enabled ? TKMStyle.radicalColor2 : TKMStyle.Color.grey33
 
-    let apiKeyEnabled = !(apiKeyField.text?.isEmpty ?? false)
-    signInWithAPIKeyButton.isEnabled = apiKeyEnabled
-    signInWithAPIKeyButton.backgroundColor = apiKeyEnabled ? TKMStyle.radicalColor2 : TKMStyle.Color
+    let apiTokenEnabled = !(apiTokenField.text?.isEmpty ?? false)
+    signInWithAPITokenButton.isEnabled = apiTokenEnabled
+    signInWithAPITokenButton.backgroundColor = apiTokenEnabled ? TKMStyle.radicalColor2 : TKMStyle.Color
       .grey33
   }
 
@@ -115,12 +115,12 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
   }
 
   @IBAction func didTapSignInWithAPIButton() {
-    if !signInWithAPIKeyButton.isEnabled {
+    if !signInWithAPITokenButton.isEnabled {
       return
     }
     showActivityIndicatorOverlay(true)
 
-    let token = apiKeyField.text!
+    let token = apiTokenField.text!
     let apiClient = WaniKaniAPIClient(apiToken: token)
     let progress = Progress()
     let promise = apiClient.user(progress: progress)

--- a/ios/LoginViewController.swift
+++ b/ios/LoginViewController.swift
@@ -104,7 +104,6 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     let promise = client.login(username: usernameField.text!, password: passwordField.text!)
     promise.done { result in
       NSLog("Login success!")
-      Settings.userCookie = result.cookie
       Settings.userApiToken = result.apiToken
       Settings.userEmailAddress = result.emailAddress
 
@@ -126,7 +125,6 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     let promise = apiClient.user(progress: progress)
     promise.done { user in
       NSLog("Login success! User is at level: \(user.currentLevel)")
-      Settings.userCookie = "apiFieldCookie" // dummy cookie since we use the API
       Settings.userApiToken = token
       Settings.userEmailAddress = ""
       self.delegate?.loginComplete()

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -497,11 +497,11 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
     isShowingUnauthorizedAlert = true
 
     let ac = UIAlertController(title: "Logged out",
-                               message: "Your API token expired, is invalid, or does not have the proper permissions. Please log in again. You won't lose your review progress.\n\nAPI tokens for the Tsurakame app cannot be expired and require all of the following permissions: assignments:start, reviews:create, study_materials:create, study_materials:update.",
+                               message: "Your API token expired, is invalid, or does not have the proper permissions. Please log in again. You won't lose your review progress.\n\nAPI tokens for the Tsurukame app cannot be expired and require all of the following permissions: assignments:start, reviews:create, study_materials:create, study_materials:update.",
                                preferredStyle: .alert)
 
     if Settings.userApiToken != "" {
-      ac.addAction(UIAlertAction(title: "Manage tokens on Wanikani", style: .default,
+      ac.addAction(UIAlertAction(title: "Manage tokens on WaniKani", style: .default,
                                  handler: { _ in
                                    self.loginAgain()
                                    if let link =

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -448,8 +448,7 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
   }
 
   func updateUserInfo() {
-    guard let user = services.localCachingClient.getUserInfo(),
-          Settings.userEmailAddress != "" else { return }
+    guard let user = services.localCachingClient.getUserInfo() else { return }
     let email = Settings.userEmailAddress
     let guruKanji = services.localCachingClient.guruKanjiCount
     let imageURL = email.isEmpty ? URL(string: kDefaultProfileImageURL)

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -497,9 +497,21 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
     isShowingUnauthorizedAlert = true
 
     let ac = UIAlertController(title: "Logged out",
-                               message: "Your API Token expired - please log in again. You won't lose your review progress",
+                               message: "Your API token expired, is invalid, or does not have the proper permissions. Please log in again. You won't lose your review progress.\n\nAPI tokens for the Tsurakame app cannot be expired and require all of the following permissions: assignments:start, reviews:create, study_materials:create, study_materials:update.",
                                preferredStyle: .alert)
 
+    if Settings.userApiToken != "" {
+      ac.addAction(UIAlertAction(title: "Manage tokens on Wanikani", style: .default,
+                                 handler: { _ in
+                                   self.loginAgain()
+                                   if let link =
+                                     URL(string: "https://www.wanikani.com/settings/personal_access_tokens#" +
+                                       Settings
+                                       .userApiToken) {
+                                     UIApplication.shared.open(link)
+                                   }
+                                 }))
+    }
     ac.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
       self.loginAgain()
     }))

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -32,19 +32,6 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="launch_screen" translatesAutoresizingMaskIntoConstraints="NO" id="2nw-3e-CvJ">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
-                            <view hidden="YES" alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5XY-Jr-SQY">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <subviews>
-                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="bBo-Lb-7ZM">
-                                        <rect key="frame" x="169" y="315" width="37" height="37"/>
-                                    </activityIndicatorView>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerY" secondItem="5XY-Jr-SQY" secondAttribute="centerY" id="GQY-l5-ae3"/>
-                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerX" secondItem="5XY-Jr-SQY" secondAttribute="centerX" id="gV4-Ll-Tbx"/>
-                                </constraints>
-                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ALW-Xn-F7M">
                                 <rect key="frame" x="67.5" y="274" width="240" height="119"/>
                                 <subviews>
@@ -109,6 +96,9 @@
                                         </connections>
                                     </button>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="240" id="cIW-O9-JOq"/>
+                                </constraints>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZdY-Fw-RIo">
                                 <rect key="frame" x="145" y="419.5" width="85" height="28"/>
@@ -127,6 +117,9 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                                <color key="shadowColor" systemColor="labelColor"/>
+                                <size key="shadowOffset" width="1" height="1"/>
+                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nzq-PL-tt3">
                                 <rect key="frame" x="145.5" y="623" width="84" height="28"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
@@ -137,14 +130,9 @@
                                     <action selector="didTapPrivacyPolicyButton" destination="RE3-Ck-N2j" eventType="touchDragInside" id="15x-gX-AOL"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign in to your WaniKani account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d7n-s4-OyH">
-                                <rect key="frame" x="57.5" y="233" width="260.5" height="21.5"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                                <color key="shadowColor" systemColor="labelColor"/>
-                                <size key="shadowOffset" width="1" height="1"/>
-                            </label>
+                            <view hidden="YES" alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5XY-Jr-SQY">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <subviews>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Rp7-Cm-oWw"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Whd-2S-WNr">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Whd-2S-WNr">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -58,11 +58,32 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
                                     </textField>
+                                    <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="viB-vI-7dJ">
+                                        <rect key="frame" x="0.0" y="81" width="240" height="0.0"/>
+                                        <subviews>
+                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="API Token" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ARP-3W-feH" userLabel="API Token">
+                                                <rect key="frame" x="0.0" y="0.0" width="195.5" height="0.0"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go"/>
+                                            </textField>
+                                            <button opaque="NO" contentMode="center" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VHN-DS-c9m">
+                                                <rect key="frame" x="195.5" y="0.0" width="44.5" height="0.0"/>
+                                                <color key="tintColor" systemColor="systemBackgroundColor"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="10" maxY="0.0"/>
+                                                <state key="normal" image="doc.on.clipboard" catalog="system"/>
+                                                <buttonConfiguration key="configuration" style="plain" image="doc.on.clipboard" catalog="system" imagePadding="10" buttonSize="small"/>
+                                                <connections>
+                                                    <action selector="didTapPasteButton:" destination="RE3-Ck-N2j" eventType="touchUpInside" id="CnR-4r-G7P"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RbB-6e-QL5">
                                         <rect key="frame" x="0.0" y="85" width="240" height="34"/>
                                         <inset key="contentEdgeInsets" minX="8" minY="8" maxX="8" maxY="8"/>
                                         <size key="titleShadowOffset" width="1" height="1"/>
-                                        <state key="normal" title="Sign in with Username/Password">
+                                        <state key="normal" title="Sign in">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <color key="titleShadowColor" systemColor="labelColor"/>
                                         </state>
@@ -78,39 +99,14 @@
                                             <action selector="didTapSignInButton" destination="RE3-Ck-N2j" eventType="touchUpInside" id="ZUH-s5-wJR"/>
                                         </connections>
                                     </button>
-                                    <textField hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="API Token" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ARP-3W-feH" userLabel="API Token">
-                                        <rect key="frame" x="0.0" y="119" width="240" height="0.0"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
-                                    </textField>
-                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YBG-Q3-yv4">
-                                        <rect key="frame" x="0.0" y="119" width="240" height="0.0"/>
-                                        <size key="titleShadowOffset" width="1" height="1"/>
-                                        <state key="normal" title="Sign in with API Token">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <color key="titleShadowColor" systemColor="labelColor"/>
-                                        </state>
-                                        <state key="disabled">
-                                            <color key="titleColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                <integer key="value" value="4"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <action selector="didTapSignInWithAPIButton" destination="RE3-Ck-N2j" eventType="touchUpInside" id="Zm4-BN-OZE"/>
-                                        </connections>
-                                    </button>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="240" id="alm-4Y-yRu"/>
                                 </constraints>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZdY-Fw-RIo">
-                                <rect key="frame" x="145" y="419.5" width="85" height="28"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <rect key="frame" x="139.5" y="418.5" width="96" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <state key="normal" title="Use API token">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="titleShadowColor" systemColor="labelColor"/>
@@ -177,12 +173,13 @@
                         <outlet property="activityIndicator" destination="bBo-Lb-7ZM" id="gRx-Lk-YKh"/>
                         <outlet property="activityIndicatorOverlay" destination="5XY-Jr-SQY" id="KpA-tS-WEt"/>
                         <outlet property="apiTokenField" destination="ARP-3W-feH" id="W49-ov-L3a"/>
+                        <outlet property="apiTokenStack" destination="viB-vI-7dJ" id="YCj-j3-cRj"/>
                         <outlet property="passwordField" destination="O4b-JI-G3n" id="DCL-CC-ZsO"/>
+                        <outlet property="pasteButton" destination="VHN-DS-c9m" id="mPu-cc-qsm"/>
                         <outlet property="privacyPolicyButton" destination="Nzq-PL-tt3" id="umc-nD-OrM"/>
                         <outlet property="privacyPolicyLabel" destination="XQW-gv-i5e" id="Aj6-Po-mXd"/>
                         <outlet property="signInButton" destination="RbB-6e-QL5" id="Oz7-Zv-7CC"/>
                         <outlet property="signInLabel" destination="d7n-s4-OyH" id="oRS-l3-TQp"/>
-                        <outlet property="signInWithAPITokenButton" destination="YBG-Q3-yv4" id="Oy3-wv-p15"/>
                         <outlet property="swapLoginMethodsButton" destination="ZdY-Fw-RIo" id="APk-UH-F4g"/>
                         <outlet property="usernameField" destination="JYP-De-NXS" id="fgx-Nt-xpx"/>
                     </connections>
@@ -407,6 +404,7 @@
         </scene>
     </scenes>
     <resources>
+        <image name="doc.on.clipboard" catalog="system" width="116" height="128"/>
         <image name="ic_search_white" width="24" height="24"/>
         <image name="ic_settings_white" width="24" height="24"/>
         <image name="launch_screen" width="1126" height="2436"/>
@@ -414,7 +412,7 @@
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -33,7 +33,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JYP-De-NXS">
-                                <rect key="frame" x="75" y="272" width="225" height="35"/>
+                                <rect key="frame" x="75" y="207.5" width="225" height="35"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="35" id="e0w-XM-Y3b"/>
@@ -42,15 +42,23 @@
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="O4b-JI-G3n">
-                                <rect key="frame" x="75" y="315" width="225" height="35"/>
+                                <rect key="frame" x="75" y="250.5" width="225" height="35"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="API Key" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ARP-3W-feH" userLabel="API Key">
+                                <rect key="frame" x="75" y="345" width="225" height="34"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RbB-6e-QL5">
-                                <rect key="frame" x="131.5" y="366" width="112.5" height="35"/>
-                                <state key="normal" title="Sign in">
+                                <rect key="frame" x="73.5" y="293" width="228" height="35"/>
+                                <size key="titleShadowOffset" width="1" height="1"/>
+                                <state key="normal" title="Sign in with Username/Password">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" systemColor="labelColor"/>
                                 </state>
                                 <state key="disabled">
                                     <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -59,14 +67,28 @@
                                     <action selector="didTapSignInButton" destination="RE3-Ck-N2j" eventType="touchUpInside" id="ZUH-s5-wJR"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YBG-Q3-yv4">
+                                <rect key="frame" x="73.5" y="388" width="228" height="35"/>
+                                <size key="titleShadowOffset" width="1" height="1"/>
+                                <state key="normal" title="Sign in with API Key">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" systemColor="labelColor"/>
+                                </state>
+                                <state key="disabled">
+                                    <color key="titleColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <connections>
+                                    <action selector="didTapSignInWithAPIButton" destination="RE3-Ck-N2j" eventType="touchUpInside" id="Zm4-BN-OZE"/>
+                                </connections>
+                            </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This app uses your WaniKani credentials to synchronise your progress with the WaniKani website." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XQW-gv-i5e">
-                                <rect key="frame" x="16" y="593.5" width="343" height="30.5"/>
+                                <rect key="frame" x="16" y="589" width="343" height="34"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nzq-PL-tt3">
-                                <rect key="frame" x="148" y="624" width="79" height="27"/>
+                                <rect key="frame" x="145.5" y="623" width="84" height="28"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <state key="normal" title="Privacy policy">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -76,10 +98,12 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign in to your WaniKani account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d7n-s4-OyH">
-                                <rect key="frame" x="77.5" y="225" width="220.5" height="17"/>
+                                <rect key="frame" x="57.5" y="156" width="260.5" height="21.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
+                                <color key="shadowColor" systemColor="labelColor"/>
+                                <size key="shadowOffset" width="1" height="1"/>
                             </label>
                             <view hidden="YES" alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5XY-Jr-SQY">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
@@ -106,6 +130,7 @@
                             <constraint firstItem="JYP-De-NXS" firstAttribute="centerX" secondItem="dX7-mn-Kqu" secondAttribute="centerX" id="GIk-Xp-Hma"/>
                             <constraint firstItem="JYP-De-NXS" firstAttribute="top" secondItem="d7n-s4-OyH" secondAttribute="bottom" constant="30" id="Hle-lx-E9S"/>
                             <constraint firstItem="d7n-s4-OyH" firstAttribute="centerX" secondItem="dX7-mn-Kqu" secondAttribute="centerX" id="HzV-nI-Nph"/>
+                            <constraint firstItem="YBG-Q3-yv4" firstAttribute="height" secondItem="RbB-6e-QL5" secondAttribute="height" id="I2F-St-NsZ"/>
                             <constraint firstItem="2nw-3e-CvJ" firstAttribute="bottom" secondItem="dX7-mn-Kqu" secondAttribute="bottom" id="I35-jy-ixE"/>
                             <constraint firstItem="2nw-3e-CvJ" firstAttribute="trailing" secondItem="dX7-mn-Kqu" secondAttribute="trailing" id="Ia3-tL-OIZ"/>
                             <constraint firstItem="O4b-JI-G3n" firstAttribute="width" secondItem="JYP-De-NXS" secondAttribute="width" id="M12-e9-WNL"/>
@@ -113,27 +138,35 @@
                             <constraint firstItem="5XY-Jr-SQY" firstAttribute="bottom" secondItem="dX7-mn-Kqu" secondAttribute="bottom" id="RrX-4Y-sRH"/>
                             <constraint firstItem="O4b-JI-G3n" firstAttribute="height" secondItem="JYP-De-NXS" secondAttribute="height" id="Ryk-Jx-yOp"/>
                             <constraint firstItem="Rp7-Cm-oWw" firstAttribute="bottom" secondItem="Nzq-PL-tt3" secondAttribute="bottom" constant="16" id="SXf-im-eLH"/>
+                            <constraint firstItem="YBG-Q3-yv4" firstAttribute="top" secondItem="ARP-3W-feH" secondAttribute="bottom" constant="9" id="THP-n4-vva"/>
                             <constraint firstItem="2nw-3e-CvJ" firstAttribute="top" secondItem="dX7-mn-Kqu" secondAttribute="top" id="Tos-NO-hAY"/>
-                            <constraint firstItem="RbB-6e-QL5" firstAttribute="top" secondItem="O4b-JI-G3n" secondAttribute="bottom" constant="16" id="d8D-xV-bAU"/>
+                            <constraint firstItem="YBG-Q3-yv4" firstAttribute="width" secondItem="RbB-6e-QL5" secondAttribute="width" id="XXI-3S-ZQB"/>
+                            <constraint firstItem="RbB-6e-QL5" firstAttribute="top" secondItem="O4b-JI-G3n" secondAttribute="bottom" constant="7.5" id="d8D-xV-bAU"/>
                             <constraint firstItem="RbB-6e-QL5" firstAttribute="height" secondItem="JYP-De-NXS" secondAttribute="height" id="eey-xG-b8n"/>
                             <constraint firstItem="XQW-gv-i5e" firstAttribute="leading" secondItem="Rp7-Cm-oWw" secondAttribute="leading" constant="16" id="fPH-ty-5QI"/>
                             <constraint firstItem="5XY-Jr-SQY" firstAttribute="trailing" secondItem="dX7-mn-Kqu" secondAttribute="trailing" id="few-EA-9bH"/>
-                            <constraint firstItem="d7n-s4-OyH" firstAttribute="centerY" secondItem="dX7-mn-Kqu" secondAttribute="centerY" multiplier="0.7" id="hjD-kw-ruH"/>
+                            <constraint firstItem="YBG-Q3-yv4" firstAttribute="centerX" secondItem="ARP-3W-feH" secondAttribute="centerX" id="hCf-CZ-nLE"/>
+                            <constraint firstItem="d7n-s4-OyH" firstAttribute="centerY" secondItem="dX7-mn-Kqu" secondAttribute="centerY" multiplier="0.5" id="hjD-kw-ruH"/>
                             <constraint firstItem="Nzq-PL-tt3" firstAttribute="centerX" secondItem="dX7-mn-Kqu" secondAttribute="centerX" id="j30-z5-gLN"/>
                             <constraint firstItem="Rp7-Cm-oWw" firstAttribute="trailing" secondItem="XQW-gv-i5e" secondAttribute="trailing" constant="16" id="jwX-SG-i0P"/>
-                            <constraint firstItem="RbB-6e-QL5" firstAttribute="width" secondItem="O4b-JI-G3n" secondAttribute="width" multiplier="0.5" id="o5b-zD-haD"/>
+                            <constraint firstItem="ARP-3W-feH" firstAttribute="centerX" secondItem="O4b-JI-G3n" secondAttribute="centerX" id="mb5-Zh-L2T"/>
+                            <constraint firstItem="ARP-3W-feH" firstAttribute="width" secondItem="O4b-JI-G3n" secondAttribute="width" id="neP-fR-puR"/>
+                            <constraint firstItem="RbB-6e-QL5" firstAttribute="width" secondItem="O4b-JI-G3n" secondAttribute="width" multiplier="0.5" constant="115.5" id="o5b-zD-haD"/>
                             <constraint firstItem="RbB-6e-QL5" firstAttribute="centerX" secondItem="dX7-mn-Kqu" secondAttribute="centerX" id="rgV-fX-6q1"/>
                             <constraint firstItem="2nw-3e-CvJ" firstAttribute="leading" secondItem="dX7-mn-Kqu" secondAttribute="leading" id="tMJ-Kr-V7q"/>
+                            <constraint firstItem="ARP-3W-feH" firstAttribute="top" secondItem="RbB-6e-QL5" secondAttribute="bottom" constant="17" id="xST-Q2-p0X"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="activityIndicator" destination="bBo-Lb-7ZM" id="gRx-Lk-YKh"/>
                         <outlet property="activityIndicatorOverlay" destination="5XY-Jr-SQY" id="KpA-tS-WEt"/>
+                        <outlet property="apiKeyField" destination="ARP-3W-feH" id="W49-ov-L3a"/>
                         <outlet property="passwordField" destination="O4b-JI-G3n" id="DCL-CC-ZsO"/>
                         <outlet property="privacyPolicyButton" destination="Nzq-PL-tt3" id="umc-nD-OrM"/>
                         <outlet property="privacyPolicyLabel" destination="XQW-gv-i5e" id="Aj6-Po-mXd"/>
                         <outlet property="signInButton" destination="RbB-6e-QL5" id="Oz7-Zv-7CC"/>
                         <outlet property="signInLabel" destination="d7n-s4-OyH" id="oRS-l3-TQp"/>
+                        <outlet property="signInWithAPIKeyButton" destination="YBG-Q3-yv4" id="Oy3-wv-p15"/>
                         <outlet property="usernameField" destination="JYP-De-NXS" id="fgx-Nt-xpx"/>
                     </connections>
                 </viewController>
@@ -362,6 +395,9 @@
         <image name="launch_screen" width="1126" height="2436"/>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -32,6 +32,19 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="launch_screen" translatesAutoresizingMaskIntoConstraints="NO" id="2nw-3e-CvJ">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
+                            <view hidden="YES" alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5XY-Jr-SQY">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <subviews>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="bBo-Lb-7ZM">
+                                        <rect key="frame" x="169" y="315" width="37" height="37"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerY" secondItem="5XY-Jr-SQY" secondAttribute="centerY" id="GQY-l5-ae3"/>
+                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerX" secondItem="5XY-Jr-SQY" secondAttribute="centerX" id="gV4-Ll-Tbx"/>
+                                </constraints>
+                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ALW-Xn-F7M">
                                 <rect key="frame" x="67.5" y="274" width="240" height="119"/>
                                 <subviews>
@@ -96,9 +109,6 @@
                                         </connections>
                                     </button>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="240" id="cIW-O9-JOq"/>
-                                </constraints>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZdY-Fw-RIo">
                                 <rect key="frame" x="145" y="419.5" width="85" height="28"/>
@@ -117,9 +127,6 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                                <color key="shadowColor" systemColor="labelColor"/>
-                                <size key="shadowOffset" width="1" height="1"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nzq-PL-tt3">
                                 <rect key="frame" x="145.5" y="623" width="84" height="28"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
@@ -130,9 +137,14 @@
                                     <action selector="didTapPrivacyPolicyButton" destination="RE3-Ck-N2j" eventType="touchDragInside" id="15x-gX-AOL"/>
                                 </connections>
                             </button>
-                            <view hidden="YES" alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5XY-Jr-SQY">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign in to your WaniKani account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d7n-s4-OyH">
+                                <rect key="frame" x="57.5" y="233" width="260.5" height="21.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                                <color key="shadowColor" systemColor="labelColor"/>
+                                <size key="shadowOffset" width="1" height="1"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Rp7-Cm-oWw"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -47,7 +47,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
                             </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="API Key" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ARP-3W-feH" userLabel="API Key">
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="API Token" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ARP-3W-feH" userLabel="API Token">
                                 <rect key="frame" x="75" y="345" width="225" height="34"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -70,7 +70,7 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YBG-Q3-yv4">
                                 <rect key="frame" x="73.5" y="388" width="228" height="35"/>
                                 <size key="titleShadowOffset" width="1" height="1"/>
-                                <state key="normal" title="Sign in with API Key">
+                                <state key="normal" title="Sign in with API Token">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="titleShadowColor" systemColor="labelColor"/>
                                 </state>
@@ -160,13 +160,13 @@
                     <connections>
                         <outlet property="activityIndicator" destination="bBo-Lb-7ZM" id="gRx-Lk-YKh"/>
                         <outlet property="activityIndicatorOverlay" destination="5XY-Jr-SQY" id="KpA-tS-WEt"/>
-                        <outlet property="apiKeyField" destination="ARP-3W-feH" id="W49-ov-L3a"/>
+                        <outlet property="apiTokenField" destination="ARP-3W-feH" id="W49-ov-L3a"/>
                         <outlet property="passwordField" destination="O4b-JI-G3n" id="DCL-CC-ZsO"/>
                         <outlet property="privacyPolicyButton" destination="Nzq-PL-tt3" id="umc-nD-OrM"/>
                         <outlet property="privacyPolicyLabel" destination="XQW-gv-i5e" id="Aj6-Po-mXd"/>
                         <outlet property="signInButton" destination="RbB-6e-QL5" id="Oz7-Zv-7CC"/>
                         <outlet property="signInLabel" destination="d7n-s4-OyH" id="oRS-l3-TQp"/>
-                        <outlet property="signInWithAPIKeyButton" destination="YBG-Q3-yv4" id="Oy3-wv-p15"/>
+                        <outlet property="signInWithAPITokenButton" destination="YBG-Q3-yv4" id="Oy3-wv-p15"/>
                         <outlet property="usernameField" destination="JYP-De-NXS" id="fgx-Nt-xpx"/>
                     </connections>
                 </viewController>

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -32,53 +32,93 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="launch_screen" translatesAutoresizingMaskIntoConstraints="NO" id="2nw-3e-CvJ">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JYP-De-NXS">
-                                <rect key="frame" x="75" y="207.5" width="225" height="35"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <view hidden="YES" alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5XY-Jr-SQY">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <subviews>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="bBo-Lb-7ZM">
+                                        <rect key="frame" x="169" y="315" width="37" height="37"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="35" id="e0w-XM-Y3b"/>
+                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerY" secondItem="5XY-Jr-SQY" secondAttribute="centerY" id="GQY-l5-ae3"/>
+                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerX" secondItem="5XY-Jr-SQY" secondAttribute="centerX" id="gV4-Ll-Tbx"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="O4b-JI-G3n">
-                                <rect key="frame" x="75" y="250.5" width="225" height="35"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="API Token" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ARP-3W-feH" userLabel="API Token">
-                                <rect key="frame" x="75" y="345" width="225" height="34"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RbB-6e-QL5">
-                                <rect key="frame" x="73.5" y="293" width="228" height="35"/>
-                                <size key="titleShadowOffset" width="1" height="1"/>
-                                <state key="normal" title="Sign in with Username/Password">
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ALW-Xn-F7M">
+                                <rect key="frame" x="67.5" y="274" width="240" height="119"/>
+                                <subviews>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JYP-De-NXS">
+                                        <rect key="frame" x="0.0" y="0.0" width="240" height="35"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="35" id="e0w-XM-Y3b"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next"/>
+                                    </textField>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="O4b-JI-G3n">
+                                        <rect key="frame" x="0.0" y="43" width="240" height="34"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
+                                    </textField>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RbB-6e-QL5">
+                                        <rect key="frame" x="0.0" y="85" width="240" height="34"/>
+                                        <inset key="contentEdgeInsets" minX="8" minY="8" maxX="8" maxY="8"/>
+                                        <size key="titleShadowOffset" width="1" height="1"/>
+                                        <state key="normal" title="Sign in with Username/Password">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleShadowColor" systemColor="labelColor"/>
+                                        </state>
+                                        <state key="disabled">
+                                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="didTapSignInButton" destination="RE3-Ck-N2j" eventType="touchUpInside" id="ZUH-s5-wJR"/>
+                                        </connections>
+                                    </button>
+                                    <textField hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="API Token" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ARP-3W-feH" userLabel="API Token">
+                                        <rect key="frame" x="0.0" y="119" width="240" height="0.0"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
+                                    </textField>
+                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YBG-Q3-yv4">
+                                        <rect key="frame" x="0.0" y="119" width="240" height="0.0"/>
+                                        <size key="titleShadowOffset" width="1" height="1"/>
+                                        <state key="normal" title="Sign in with API Token">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleShadowColor" systemColor="labelColor"/>
+                                        </state>
+                                        <state key="disabled">
+                                            <color key="titleColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="4"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="didTapSignInWithAPIButton" destination="RE3-Ck-N2j" eventType="touchUpInside" id="Zm4-BN-OZE"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZdY-Fw-RIo">
+                                <rect key="frame" x="145" y="419.5" width="85" height="28"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <state key="normal" title="Use API token">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="titleShadowColor" systemColor="labelColor"/>
                                 </state>
-                                <state key="disabled">
-                                    <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
                                 <connections>
-                                    <action selector="didTapSignInButton" destination="RE3-Ck-N2j" eventType="touchUpInside" id="ZUH-s5-wJR"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YBG-Q3-yv4">
-                                <rect key="frame" x="73.5" y="388" width="228" height="35"/>
-                                <size key="titleShadowOffset" width="1" height="1"/>
-                                <state key="normal" title="Sign in with API Token">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                    <color key="titleShadowColor" systemColor="labelColor"/>
-                                </state>
-                                <state key="disabled">
-                                    <color key="titleColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                                <connections>
-                                    <action selector="didTapSignInWithAPIButton" destination="RE3-Ck-N2j" eventType="touchUpInside" id="Zm4-BN-OZE"/>
+                                    <action selector="didTapSwapLoginMethods" destination="RE3-Ck-N2j" eventType="touchUpInside" id="zOl-5j-AS0"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This app uses your WaniKani credentials to synchronise your progress with the WaniKani website." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XQW-gv-i5e">
@@ -98,63 +138,36 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign in to your WaniKani account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d7n-s4-OyH">
-                                <rect key="frame" x="57.5" y="156" width="260.5" height="21.5"/>
+                                <rect key="frame" x="57.5" y="233" width="260.5" height="21.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                                 <color key="shadowColor" systemColor="labelColor"/>
                                 <size key="shadowOffset" width="1" height="1"/>
                             </label>
-                            <view hidden="YES" alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5XY-Jr-SQY">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <subviews>
-                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="bBo-Lb-7ZM">
-                                        <rect key="frame" x="169" y="315" width="37" height="37"/>
-                                    </activityIndicatorView>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerY" secondItem="5XY-Jr-SQY" secondAttribute="centerY" id="GQY-l5-ae3"/>
-                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerX" secondItem="5XY-Jr-SQY" secondAttribute="centerX" id="gV4-Ll-Tbx"/>
-                                </constraints>
-                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Rp7-Cm-oWw"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="O4b-JI-G3n" firstAttribute="top" secondItem="JYP-De-NXS" secondAttribute="bottom" constant="8" id="BN6-Ne-mqR"/>
                             <constraint firstItem="Nzq-PL-tt3" firstAttribute="top" secondItem="XQW-gv-i5e" secondAttribute="bottom" id="CFp-Ks-pDH"/>
                             <constraint firstItem="5XY-Jr-SQY" firstAttribute="leading" secondItem="dX7-mn-Kqu" secondAttribute="leading" id="EP2-Ed-FHs"/>
-                            <constraint firstItem="O4b-JI-G3n" firstAttribute="centerX" secondItem="dX7-mn-Kqu" secondAttribute="centerX" id="Ffs-Mo-Oj5"/>
                             <constraint firstItem="5XY-Jr-SQY" firstAttribute="top" secondItem="dX7-mn-Kqu" secondAttribute="top" id="GAv-il-7KY"/>
-                            <constraint firstItem="JYP-De-NXS" firstAttribute="centerX" secondItem="dX7-mn-Kqu" secondAttribute="centerX" id="GIk-Xp-Hma"/>
-                            <constraint firstItem="JYP-De-NXS" firstAttribute="top" secondItem="d7n-s4-OyH" secondAttribute="bottom" constant="30" id="Hle-lx-E9S"/>
                             <constraint firstItem="d7n-s4-OyH" firstAttribute="centerX" secondItem="dX7-mn-Kqu" secondAttribute="centerX" id="HzV-nI-Nph"/>
-                            <constraint firstItem="YBG-Q3-yv4" firstAttribute="height" secondItem="RbB-6e-QL5" secondAttribute="height" id="I2F-St-NsZ"/>
                             <constraint firstItem="2nw-3e-CvJ" firstAttribute="bottom" secondItem="dX7-mn-Kqu" secondAttribute="bottom" id="I35-jy-ixE"/>
                             <constraint firstItem="2nw-3e-CvJ" firstAttribute="trailing" secondItem="dX7-mn-Kqu" secondAttribute="trailing" id="Ia3-tL-OIZ"/>
-                            <constraint firstItem="O4b-JI-G3n" firstAttribute="width" secondItem="JYP-De-NXS" secondAttribute="width" id="M12-e9-WNL"/>
-                            <constraint firstItem="JYP-De-NXS" firstAttribute="width" secondItem="dX7-mn-Kqu" secondAttribute="width" multiplier="0.6" id="OiL-YV-IPK"/>
+                            <constraint firstItem="ALW-Xn-F7M" firstAttribute="centerY" secondItem="Rp7-Cm-oWw" secondAttribute="centerY" id="Oih-nr-rVO"/>
                             <constraint firstItem="5XY-Jr-SQY" firstAttribute="bottom" secondItem="dX7-mn-Kqu" secondAttribute="bottom" id="RrX-4Y-sRH"/>
-                            <constraint firstItem="O4b-JI-G3n" firstAttribute="height" secondItem="JYP-De-NXS" secondAttribute="height" id="Ryk-Jx-yOp"/>
+                            <constraint firstItem="ALW-Xn-F7M" firstAttribute="centerX" secondItem="Rp7-Cm-oWw" secondAttribute="centerX" id="S46-jY-dQh"/>
                             <constraint firstItem="Rp7-Cm-oWw" firstAttribute="bottom" secondItem="Nzq-PL-tt3" secondAttribute="bottom" constant="16" id="SXf-im-eLH"/>
-                            <constraint firstItem="YBG-Q3-yv4" firstAttribute="top" secondItem="ARP-3W-feH" secondAttribute="bottom" constant="9" id="THP-n4-vva"/>
                             <constraint firstItem="2nw-3e-CvJ" firstAttribute="top" secondItem="dX7-mn-Kqu" secondAttribute="top" id="Tos-NO-hAY"/>
-                            <constraint firstItem="YBG-Q3-yv4" firstAttribute="width" secondItem="RbB-6e-QL5" secondAttribute="width" id="XXI-3S-ZQB"/>
-                            <constraint firstItem="RbB-6e-QL5" firstAttribute="top" secondItem="O4b-JI-G3n" secondAttribute="bottom" constant="7.5" id="d8D-xV-bAU"/>
-                            <constraint firstItem="RbB-6e-QL5" firstAttribute="height" secondItem="JYP-De-NXS" secondAttribute="height" id="eey-xG-b8n"/>
                             <constraint firstItem="XQW-gv-i5e" firstAttribute="leading" secondItem="Rp7-Cm-oWw" secondAttribute="leading" constant="16" id="fPH-ty-5QI"/>
                             <constraint firstItem="5XY-Jr-SQY" firstAttribute="trailing" secondItem="dX7-mn-Kqu" secondAttribute="trailing" id="few-EA-9bH"/>
-                            <constraint firstItem="YBG-Q3-yv4" firstAttribute="centerX" secondItem="ARP-3W-feH" secondAttribute="centerX" id="hCf-CZ-nLE"/>
-                            <constraint firstItem="d7n-s4-OyH" firstAttribute="centerY" secondItem="dX7-mn-Kqu" secondAttribute="centerY" multiplier="0.5" id="hjD-kw-ruH"/>
+                            <constraint firstItem="d7n-s4-OyH" firstAttribute="centerY" secondItem="dX7-mn-Kqu" secondAttribute="centerY" constant="-90" id="hjD-kw-ruH"/>
                             <constraint firstItem="Nzq-PL-tt3" firstAttribute="centerX" secondItem="dX7-mn-Kqu" secondAttribute="centerX" id="j30-z5-gLN"/>
                             <constraint firstItem="Rp7-Cm-oWw" firstAttribute="trailing" secondItem="XQW-gv-i5e" secondAttribute="trailing" constant="16" id="jwX-SG-i0P"/>
-                            <constraint firstItem="ARP-3W-feH" firstAttribute="centerX" secondItem="O4b-JI-G3n" secondAttribute="centerX" id="mb5-Zh-L2T"/>
-                            <constraint firstItem="ARP-3W-feH" firstAttribute="width" secondItem="O4b-JI-G3n" secondAttribute="width" id="neP-fR-puR"/>
-                            <constraint firstItem="RbB-6e-QL5" firstAttribute="width" secondItem="O4b-JI-G3n" secondAttribute="width" multiplier="0.5" constant="115.5" id="o5b-zD-haD"/>
-                            <constraint firstItem="RbB-6e-QL5" firstAttribute="centerX" secondItem="dX7-mn-Kqu" secondAttribute="centerX" id="rgV-fX-6q1"/>
+                            <constraint firstItem="ZdY-Fw-RIo" firstAttribute="centerY" secondItem="Rp7-Cm-oWw" secondAttribute="centerY" constant="100" id="si1-qd-eM8"/>
                             <constraint firstItem="2nw-3e-CvJ" firstAttribute="leading" secondItem="dX7-mn-Kqu" secondAttribute="leading" id="tMJ-Kr-V7q"/>
-                            <constraint firstItem="ARP-3W-feH" firstAttribute="top" secondItem="RbB-6e-QL5" secondAttribute="bottom" constant="17" id="xST-Q2-p0X"/>
+                            <constraint firstItem="ZdY-Fw-RIo" firstAttribute="centerX" secondItem="ALW-Xn-F7M" secondAttribute="centerX" id="vZn-4k-6Fq"/>
                         </constraints>
                     </view>
                     <connections>
@@ -167,6 +180,7 @@
                         <outlet property="signInButton" destination="RbB-6e-QL5" id="Oz7-Zv-7CC"/>
                         <outlet property="signInLabel" destination="d7n-s4-OyH" id="oRS-l3-TQp"/>
                         <outlet property="signInWithAPITokenButton" destination="YBG-Q3-yv4" id="Oy3-wv-p15"/>
+                        <outlet property="swapLoginMethodsButton" destination="ZdY-Fw-RIo" id="APk-UH-F4g"/>
                         <outlet property="usernameField" destination="JYP-De-NXS" id="fgx-Nt-xpx"/>
                     </connections>
                 </viewController>

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -32,19 +32,14 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="launch_screen" translatesAutoresizingMaskIntoConstraints="NO" id="2nw-3e-CvJ">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
-                            <view hidden="YES" alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5XY-Jr-SQY">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <subviews>
-                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="bBo-Lb-7ZM">
-                                        <rect key="frame" x="169" y="315" width="37" height="37"/>
-                                    </activityIndicatorView>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerY" secondItem="5XY-Jr-SQY" secondAttribute="centerY" id="GQY-l5-ae3"/>
-                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerX" secondItem="5XY-Jr-SQY" secondAttribute="centerX" id="gV4-Ll-Tbx"/>
-                                </constraints>
-                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign in to your WaniKani account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d7n-s4-OyH">
+                                <rect key="frame" x="57.5" y="233" width="260.5" height="21.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                                <color key="shadowColor" systemColor="labelColor"/>
+                                <size key="shadowOffset" width="1" height="1"/>
+                            </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ALW-Xn-F7M">
                                 <rect key="frame" x="67.5" y="274" width="240" height="119"/>
                                 <subviews>
@@ -109,6 +104,9 @@
                                         </connections>
                                     </button>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="240" id="alm-4Y-yRu"/>
+                                </constraints>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZdY-Fw-RIo">
                                 <rect key="frame" x="145" y="419.5" width="85" height="28"/>
@@ -121,12 +119,6 @@
                                     <action selector="didTapSwapLoginMethods" destination="RE3-Ck-N2j" eventType="touchUpInside" id="zOl-5j-AS0"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This app uses your WaniKani credentials to synchronise your progress with the WaniKani website." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XQW-gv-i5e">
-                                <rect key="frame" x="16" y="589" width="343" height="34"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nzq-PL-tt3">
                                 <rect key="frame" x="145.5" y="623" width="84" height="28"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
@@ -137,14 +129,25 @@
                                     <action selector="didTapPrivacyPolicyButton" destination="RE3-Ck-N2j" eventType="touchDragInside" id="15x-gX-AOL"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign in to your WaniKani account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d7n-s4-OyH">
-                                <rect key="frame" x="57.5" y="233" width="260.5" height="21.5"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This app uses your WaniKani credentials to synchronise your progress with the WaniKani website." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XQW-gv-i5e">
+                                <rect key="frame" x="16" y="589" width="343" height="34"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
-                                <color key="shadowColor" systemColor="labelColor"/>
-                                <size key="shadowOffset" width="1" height="1"/>
                             </label>
+                            <view hidden="YES" alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5XY-Jr-SQY">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <subviews>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="bBo-Lb-7ZM">
+                                        <rect key="frame" x="169" y="315" width="37" height="37"/>
+                                    </activityIndicatorView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerY" secondItem="5XY-Jr-SQY" secondAttribute="centerY" id="GQY-l5-ae3"/>
+                                    <constraint firstItem="bBo-Lb-7ZM" firstAttribute="centerX" secondItem="5XY-Jr-SQY" secondAttribute="centerX" id="gV4-Ll-Tbx"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Rp7-Cm-oWw"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
Adds alternative login method using API token rather than username/password credentials. User has the option to use one login method or the other, so this should not turn people away from using the app at all.

I did have to tweak the layout of the main login screen to accommodate the extra height. Also tweaked the shadow to make it more readable since the main Sign In text moved into a lighter background, but that's arguably opinionated and can be easily removed. See below screenshot.

Downside: User email address cannot be obtained via the API, thus making the gravatar fetch not work. In theory, we could add a setting that would allow users to override their email address used for Gravatar pulling. Is this a good option, or is there another way to grab the user's email address without web scraping that I missed...?

![simulator_screenshot_CA922CBE-1CAF-4E92-B9D4-63FE9DF04CEB](https://user-images.githubusercontent.com/5092399/210260218-14a065c0-b14d-4fa0-aa90-9ad854cd6022.png)

Closes #571 