### PR TITLE
Add option for viewing current level graph before finishing vocab

### DIFF
--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -502,16 +502,6 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
     return !assignments.contains { !$0.hasPassedAt }
   }
 
-  func getAssignmentsAtUsersCurrentGraphLevel() -> [TKMAssignment] {
-    guard let userInfo = getUserInfo() else {
-      return []
-    }
-    if Settings.showPreviousLevelGraph, !hasCompletedPreviousLevel() {
-      return getAssignments(level: Int(userInfo.level) - 1)
-    }
-    return getAssignments(level: Int(userInfo.level))
-  }
-
   private func getAssignments(level: Int, transaction db: FMDatabase) -> [TKMAssignment] {
     var ret = [TKMAssignment]()
     var subjectIds = Set<Int>()

--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -498,13 +498,8 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
       level = level - 1
     }
     let assignments = getAssignments(level: level)
-    var isDoneWithPreviousLevel = true
-    for assignment in assignments {
-      if assignment.srsStageNumber == level, !assignment.hasPassedAt {
-        isDoneWithPreviousLevel = false
-      }
-    }
-    return isDoneWithPreviousLevel
+    // if any assignment has not been passed, they have not passed the prior level
+    return !assignments.contains { !$0.hasPassedAt }
   }
 
   func getAssignmentsAtUsersCurrentGraphLevel() -> [TKMAssignment] {

--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -489,6 +489,34 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
     return getAssignments(level: Int(userInfo.level))
   }
 
+  func hasCompletedPreviousLevel() -> Bool {
+    guard let userInfo = getUserInfo() else {
+      return false
+    }
+    var level = Int(userInfo.level)
+    if level > 1 {
+      level = level - 1
+    }
+    let assignments = getAssignments(level: level)
+    var isDoneWithPreviousLevel = true
+    for assignment in assignments {
+      if assignment.srsStageNumber == level, !assignment.hasPassedAt {
+        isDoneWithPreviousLevel = false
+      }
+    }
+    return isDoneWithPreviousLevel
+  }
+
+  func getAssignmentsAtUsersCurrentGraphLevel() -> [TKMAssignment] {
+    guard let userInfo = getUserInfo() else {
+      return []
+    }
+    if Settings.showPreviousLevelGraph, !hasCompletedPreviousLevel() {
+      return getAssignments(level: Int(userInfo.level) - 1)
+    }
+    return getAssignments(level: Int(userInfo.level))
+  }
+
   private func getAssignments(level: Int, transaction db: FMDatabase) -> [TKMAssignment] {
     var ret = [TKMAssignment]()
     var subjectIds = Set<Int>()

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -201,7 +201,7 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
       model.add(section: "Current level (\(user.currentLevel > 1 ? user.currentLevel - 1 : 1))")
       let currentGraphLevelAssignments = services.localCachingClient.getAssignments(level: Int(user.currentLevel) - 1)
       model.add(CurrentLevelChartItem(currentLevelAssignments: currentGraphLevelAssignments))
-      model.add(section: "Next level")
+      model.add(section: "Next level (\(user.currentLevel))")
     } else {
       model.add(section: "Current level")
     }

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -197,10 +197,9 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
                                               currentLevelAssignments: currentLevelAssignments))
     }
 
-    if Settings.showPreviousLevelGraph, !services.localCachingClient.hasCompletedPreviousLevel() {
+    if Settings.showPreviousLevelGraph, user.currentLevel > 1, !services.localCachingClient.hasCompletedPreviousLevel() {
       model.add(section: "Current level (\(user.currentLevel > 1 ? user.currentLevel - 1 : 1))")
-      let currentGraphLevelAssignments = services.localCachingClient
-        .getAssignmentsAtUsersCurrentGraphLevel()
+      let currentGraphLevelAssignments = services.localCachingClient.getAssignments(level: Int(user.currentLevel) - 1)
       model.add(CurrentLevelChartItem(currentLevelAssignments: currentGraphLevelAssignments))
       model.add(section: "Next level")
     } else {

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -197,7 +197,16 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
                                               currentLevelAssignments: currentLevelAssignments))
     }
 
-    model.add(section: "This level")
+    if Settings.showPreviousLevelGraph, !services.localCachingClient.hasCompletedPreviousLevel() {
+      model.add(section: "Current level (\(user.currentLevel > 1 ? user.currentLevel - 1 : 1))")
+      let currentGraphLevelAssignments = services.localCachingClient
+        .getAssignmentsAtUsersCurrentGraphLevel()
+      model.add(CurrentLevelChartItem(currentLevelAssignments: currentGraphLevelAssignments))
+      model.add(section: "Next level")
+    } else {
+      model.add(section: "Current level")
+    }
+
     model.add(CurrentLevelChartItem(currentLevelAssignments: currentLevelAssignments))
 
     if !user.hasVacationStartedAt {

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -341,7 +341,13 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
     case "showRemaining":
       let vc = segue.destination as! SubjectsRemainingViewController
-      vc.setup(services: services)
+      guard var level = services.localCachingClient.getUserInfo()?.level else {
+        return
+      }
+      if self.isShowingPriorUserLevel, self.model.tableView.indexPathForSelectedRow!.section == self.currLevelSectionIndex {
+        level = level - 1
+      }
+      vc.setup(services: services, level: Int(level))
 
     case "settings":
       let vc = segue.destination as! SettingsViewController

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -574,14 +574,6 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
     performSegue(withIdentifier: "startLessons", sender: self)
   }
 
-  @objc func showRemaining() {
-    performSegue(withIdentifier: "showRemaining", sender: self)
-  }
-
-  @objc func showAll() {
-    performSegue(withIdentifier: "showAll", sender: self)
-  }
-
   @objc func showTableForecast() {
     performSegue(withIdentifier: "tableForecast", sender: self)
   }

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -60,7 +60,7 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
   var hasLessons = false
   var hasReviews = false
   var updatingTableModel = false
-  
+
   var isShowingPriorUserLevel = false
   var currLevelSectionIndex = -1
 
@@ -160,10 +160,10 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
   private func recreateTableModel() {
     guard let user = services.localCachingClient.getUserInfo() else { return }
-    
+
     // make sure that section indices are reset each time table is loaded in case things change
-    self.isShowingPriorUserLevel = false
-    self.currLevelSectionIndex = -1
+    isShowingPriorUserLevel = false
+    currLevelSectionIndex = -1
 
     let lessons = services.localCachingClient.availableLessonCount
     let reviews = services.localCachingClient.availableReviewCount
@@ -204,16 +204,19 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
                                               currentLevelAssignments: currentLevelAssignments))
     }
 
-    if Settings.showPreviousLevelGraph, user.currentLevel > 1, !services.localCachingClient.hasCompletedPreviousLevel() {
-      self.isShowingPriorUserLevel = true
-      self.currLevelSectionIndex = model.add(section: "Current level (\(user.currentLevel > 1 ? user.currentLevel - 1 : 1))")
-      let currentGraphLevelAssignments = services.localCachingClient.getAssignments(level: Int(user.currentLevel) - 1)
+    if Settings.showPreviousLevelGraph, user.currentLevel > 1,
+       !services.localCachingClient.hasCompletedPreviousLevel() {
+      isShowingPriorUserLevel = true
+      currLevelSectionIndex = model
+        .add(section: "Current level (\(user.currentLevel > 1 ? user.currentLevel - 1 : 1))")
+      let currentGraphLevelAssignments = services.localCachingClient
+        .getAssignments(level: Int(user.currentLevel) - 1)
       model.add(CurrentLevelChartItem(currentLevelAssignments: currentGraphLevelAssignments))
-      self.addShowRemainingAllItems(model: model)
+      addShowRemainingAllItems(model: model)
       // add header for next section; graph and other items will be added after this if/else block
       model.add(section: "Next level (\(user.currentLevel))")
     } else {
-      self.currLevelSectionIndex = model.add(section: "Current level")
+      currLevelSectionIndex = model.add(section: "Current level")
     }
 
     model.add(CurrentLevelChartItem(currentLevelAssignments: currentLevelAssignments))
@@ -223,7 +226,7 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
         .add(createLevelTimeRemainingItem(services: services,
                                           currentLevelAssignments: currentLevelAssignments))
     }
-    self.addShowRemainingAllItems(model: model)
+    addShowRemainingAllItems(model: model)
 
     model.add(section: "All levels")
     for category in SRSStageCategory.apprentice ... SRSStageCategory.burned {
@@ -236,8 +239,8 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
     updateUserInfo()
   }
-  
-  private func addShowRemainingAllItems(model :MutableTableModel) {
+
+  private func addShowRemainingAllItems(model: MutableTableModel) {
     model.add(BasicModelItem(style: .default,
                              title: "Show remaining",
                              subtitle: nil,
@@ -334,7 +337,8 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
     case "showAll":
       let vc = segue.destination as! SubjectCatalogueViewController
       var level = services.localCachingClient.getUserInfo()!.level
-      if self.isShowingPriorUserLevel, self.model.tableView.indexPathForSelectedRow!.section == self.currLevelSectionIndex {
+      if isShowingPriorUserLevel,
+         model.tableView.indexPathForSelectedRow!.section == currLevelSectionIndex {
         level = level - 1
       }
       vc.setup(services: services, level: Int(level))
@@ -342,7 +346,8 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
     case "showRemaining":
       let vc = segue.destination as! SubjectsRemainingViewController
       var level = services.localCachingClient.getUserInfo()!.level
-      if self.isShowingPriorUserLevel, self.model.tableView.indexPathForSelectedRow!.section == self.currLevelSectionIndex {
+      if isShowingPriorUserLevel,
+         model.tableView.indexPathForSelectedRow!.section == currLevelSectionIndex {
         level = level - 1
       }
       vc.setup(services: services, level: Int(level))

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -341,9 +341,7 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
     case "showRemaining":
       let vc = segue.destination as! SubjectsRemainingViewController
-      guard var level = services.localCachingClient.getUserInfo()?.level else {
-        return
-      }
+      var level = services.localCachingClient.getUserInfo()!.level
       if self.isShowingPriorUserLevel, self.model.tableView.indexPathForSelectedRow!.section == self.currLevelSectionIndex {
         level = level - 1
       }

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -194,6 +194,7 @@ protocol SettingProtocol {
   @Setting(false, #keyPath(allowSkippingReviews)) static var allowSkippingReviews: Bool
   @Setting(true, #keyPath(minimizeReviewPenalty)) static var minimizeReviewPenalty: Bool
   @Setting(false, #keyPath(ankiMode)) static var ankiMode: Bool
+  @Setting(false, #keyPath(showPreviousLevelGraph)) static var showPreviousLevelGraph: Bool
 
   @Setting(false, #keyPath(seenFullAnswerPrompt)) static var seenFullAnswerPrompt: Bool
 

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -194,7 +194,7 @@ protocol SettingProtocol {
   @Setting(false, #keyPath(allowSkippingReviews)) static var allowSkippingReviews: Bool
   @Setting(true, #keyPath(minimizeReviewPenalty)) static var minimizeReviewPenalty: Bool
   @Setting(false, #keyPath(ankiMode)) static var ankiMode: Bool
-  @Setting(false, #keyPath(showPreviousLevelGraph)) static var showPreviousLevelGraph: Bool
+  @Setting(true, #keyPath(showPreviousLevelGraph)) static var showPreviousLevelGraph: Bool
 
   @Setting(false, #keyPath(seenFullAnswerPrompt)) static var seenFullAnswerPrompt: Bool
 

--- a/ios/SubjectDetailsSettingsViewController.swift
+++ b/ios/SubjectDetailsSettingsViewController.swift
@@ -59,6 +59,14 @@ class SubjectDetailsSettingsViewController: UITableViewController, TKMViewContro
                               on: Settings.showOldMnemonic,
                               target: self,
                               action: #selector(showOldMnemonicSwitchChanged(_:))))
+    let currentLevelGraphItem = SwitchModelItem(style: .subtitle,
+                                                title: "Keep current level graph",
+                                                subtitle: "Instead of showing the next level's graph when you finish the kanji for a given level, keep showing the same level completion graph until all radicals, kanji, and vocabulary have gotten to Guru or higher",
+                                                on: Settings.showPreviousLevelGraph,
+                                                target: self,
+                                                action: #selector(levelGraphSwitchChanged(_:)))
+    currentLevelGraphItem.numberOfSubtitleLines = 0
+    model.add(currentLevelGraphItem)
 
     self.model = model
     model.reloadTable()
@@ -80,5 +88,9 @@ class SubjectDetailsSettingsViewController: UITableViewController, TKMViewContro
 
   @objc private func showAllReadingsSwitchChanged(_ switchView: UISwitch) {
     Settings.showAllReadings = switchView.isOn
+  }
+
+  @objc private func levelGraphSwitchChanged(_ switchView: UISwitch) {
+    Settings.showPreviousLevelGraph = switchView.isOn
   }
 }

--- a/ios/SubjectsRemainingViewController.swift
+++ b/ios/SubjectsRemainingViewController.swift
@@ -19,9 +19,11 @@ class SubjectsRemainingViewController: UITableViewController, SubjectDelegate,
   TKMViewController {
   var services: TKMServices!
   var model: TableModel?
+  private var level: Int!
 
-  func setup(services: TKMServices) {
+  func setup(services: TKMServices, level: Int) {
     self.services = services
+    self.level = level
   }
 
   // MARK: - TKMViewController
@@ -33,14 +35,12 @@ class SubjectsRemainingViewController: UITableViewController, SubjectDelegate,
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    guard let level = services.localCachingClient.getUserInfo()?.level else {
-      return
-    }
-    navigationItem.title = "Remaining in Level \(level)"
+    navigationItem.title = "Remaining in Level \(self.level!)"
 
     var radicals = [SubjectModelItem]()
     var kanji = [SubjectModelItem]()
-    for assignment in services.localCachingClient.getAssignmentsAtUsersCurrentLevel() {
+    var vocabulary = [SubjectModelItem]()
+    for assignment in services.localCachingClient.getAssignments(level: self.level) {
       if assignment.srsStage > .apprentice4 {
         continue
       }
@@ -48,7 +48,7 @@ class SubjectsRemainingViewController: UITableViewController, SubjectDelegate,
       else {
         continue
       }
-      if subject.subjectType == .vocabulary {
+      if !Settings.showPreviousLevelGraph, subject.subjectType == .vocabulary {
         continue
       }
 
@@ -65,6 +65,8 @@ class SubjectsRemainingViewController: UITableViewController, SubjectDelegate,
         radicals.append(item)
       case .kanji:
         kanji.append(item)
+      case .vocabulary:
+        vocabulary.append(item)
       default:
         break
       }
@@ -80,6 +82,12 @@ class SubjectsRemainingViewController: UITableViewController, SubjectDelegate,
     if !kanji.isEmpty {
       model.add(section: "Kanji")
       for item in kanji {
+        model.add(item)
+      }
+    }
+    if !vocabulary.isEmpty {
+      model.add(section: "Vocabulary")
+      for item in vocabulary {
         model.add(item)
       }
     }

--- a/ios/SubjectsRemainingViewController.swift
+++ b/ios/SubjectsRemainingViewController.swift
@@ -19,7 +19,7 @@ class SubjectsRemainingViewController: UITableViewController, SubjectDelegate,
   TKMViewController {
   var services: TKMServices!
   var model: TableModel?
-  private var level: Int!
+  private var level: Int = 0
 
   func setup(services: TKMServices, level: Int) {
     self.services = services
@@ -35,7 +35,7 @@ class SubjectsRemainingViewController: UITableViewController, SubjectDelegate,
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    navigationItem.title = "Remaining in Level \(level!)"
+    navigationItem.title = "Remaining in Level \(level)"
 
     var radicals = [SubjectModelItem]()
     var kanji = [SubjectModelItem]()

--- a/ios/SubjectsRemainingViewController.swift
+++ b/ios/SubjectsRemainingViewController.swift
@@ -35,12 +35,12 @@ class SubjectsRemainingViewController: UITableViewController, SubjectDelegate,
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    navigationItem.title = "Remaining in Level \(self.level!)"
+    navigationItem.title = "Remaining in Level \(level!)"
 
     var radicals = [SubjectModelItem]()
     var kanji = [SubjectModelItem]()
     var vocabulary = [SubjectModelItem]()
-    for assignment in services.localCachingClient.getAssignments(level: self.level) {
+    for assignment in services.localCachingClient.getAssignments(level: level) {
       if assignment.srsStage > .apprentice4 {
         continue
       }


### PR DESCRIPTION
One downside to passing kanji is that you level up before you finish vocabulary. For those of us who are ordering things such that we finish vocab before we start the next level's radicals/kanji, it would be useful to see a graph of our current progress.

This PR adds a setting to enable that. If active, it will check to see if the user's previous level (the one where they have vocabulary) is done or not. If it is not done, a second graph is shown on the home screen with the title `Current Level (#)`, and then the user's _actual_ current level graph is titled with `Next Level`. If the setting is on and the user has finished the prior level, it will only show the current level's graph.

I also renamed `This Level` to `Current Level` if the setting is off (or does not apply); that is more of a subjective change that doesn't necessarily need to come in. I just thought it would make sense if we always have "current level" and "next level", as if the user is done with the prior level, the section title would change from "Next Level" to "This Level", which might end up being confusing.

![Simulator Screen Shot - iPhone SE (2nd generation) - 2023-01-02 at 12 00 12](https://user-images.githubusercontent.com/5092399/210261074-e4d5b45e-00b9-494a-a83b-3d0d6417206e.png)

![Simulator Screen Shot - iPhone SE (2nd generation) - 2023-01-02 at 12 00 19](https://user-images.githubusercontent.com/5092399/210261130-ad6ae93e-db6e-47d9-b920-7f415014ff2c.png)

Related to: #219
