### PR TITLE
Force text back to center after kana replacement

### DIFF
--- a/ios/TKMKanaInput.m
+++ b/ios/TKMKanaInput.m
@@ -406,6 +406,8 @@ NSString *TKMConvertKanaText(NSString *input) {
       textField.text =
           [textField.text stringByReplacingCharactersInRange:NSMakeRange(range.location - 1, 1)
                                                   withString:replacementString];
+      [textField setTextAlignment:NSTextAlignmentCenter];
+
       return YES;
     }
 
@@ -417,6 +419,8 @@ NSString *TKMConvertKanaText(NSString *input) {
       textField.text =
           [textField.text stringByReplacingCharactersInRange:NSMakeRange(range.location - 1, 1)
                                                   withString:replacementString];
+      [textField setTextAlignment:NSTextAlignmentCenter];
+
       return YES;
     }
   }
@@ -442,6 +446,8 @@ NSString *TKMConvertKanaText(NSString *input) {
       }
       textField.text = [textField.text stringByReplacingCharactersInRange:replacementRange
                                                                withString:replacement];
+      [textField setTextAlignment:NSTextAlignmentCenter];
+
       return NO;
     }
   }


### PR DESCRIPTION
I have no idea why this is now breaking sometimes on Mac, in both Catalyst and iPad modes. This fixes the text suddenly becoming left-aligned after every replacement of kana, but it does not fix the text suddenly jumping to the left if you click inside the text field.

I wasn't able to figure out how to force the text back to the center when you click on the text field. My attempts to intercept `becomeFirstResponder` and `textFieldDidBeginEditing` didn't work, but I don't know if it's because that isn't the problem or if it's because I am not good enough at UIKit. 😅

**Before**

https://user-images.githubusercontent.com/78/221395112-803e97b5-bf66-4a14-9ed5-4cef7574a448.mp4

**After**

https://user-images.githubusercontent.com/78/221395123-38077bba-1eed-400c-a971-7f20e594a8df.mp4

