### PR TITLE
Fix iOS 12 crash

### DIFF
--- a/ios/WaniKaniAPI/Sources/WaniKaniAPI/HTTPURLResponse+valueForHeaderField.swift
+++ b/ios/WaniKaniAPI/Sources/WaniKaniAPI/HTTPURLResponse+valueForHeaderField.swift
@@ -22,7 +22,7 @@ public extension HTTPURLResponse {
       let lowerHeaderField = headerField.lowercased()
       return allHeaderFields.first { key, _ in
         (key as! String).lowercased() == lowerHeaderField
-      } as! String?
+      }?.value as? String
     }
   }
 }


### PR DESCRIPTION
Fix #619 with a one-line fix to a polyfill for iOS 12.

I have tested this PR in the iOS 12 simulator and confirmed it fixes the crash.