### PR TITLE
Have the font used for context sentences change size depending on accessibility options.

### DIFF
--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -17,7 +17,11 @@ import WaniKaniAPI
 
 private let kSectionHeaderHeight: CGFloat = 38.0
 private let kSectionFooterHeight: CGFloat = 0.0
-private let kFontSize: CGFloat = 14.0
+
+private let kFontSize: CGFloat = {
+  let bodyFontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body)
+  return bodyFontDescriptor.pointSize
+}()
 
 private let kMeaningSynonymColor = UIColor(red: 0.231, green: 0.6, blue: 0.988, alpha: 1)
 private let kFont = TKMStyle.japaneseFont(size: kFontSize)


### PR DESCRIPTION
Content sentences are too small for my aging eyesight. This pull request scales the font size depending on the accessibility settings under:
Display & Text Size -> Larger Text 

![Screenshot 2023-05-19 at 15 44 32](https://github.com/davidsansome/tsurukame/assets/2806093/aac87fc2-212e-48a8-8049-cd98a81c91b7)

Fixes #624 