### PR TITLE
Critical Bugfix: crash when する appears

### DIFF
--- a/ios/VocabularyHighlighter.swift
+++ b/ios/VocabularyHighlighter.swift
@@ -237,7 +237,7 @@ private class ConjugationGroup {
     case .ichidanVerb:
       return ichidanVerb
     case .suruVerb:
-      return suruVerb
+      return ichidanVerb //suruVerb
     case .iAdjective:
       return iAdjective
     case .naAdjective:

--- a/ios/VocabularyHighlighter.swift
+++ b/ios/VocabularyHighlighter.swift
@@ -237,7 +237,7 @@ private class ConjugationGroup {
     case .ichidanVerb:
       return ichidanVerb
     case .suruVerb:
-      return ichidanVerb //suruVerb
+      return suruVerb
     case .iAdjective:
       return iAdjective
     case .naAdjective:
@@ -264,7 +264,9 @@ func patternToHighlight(for subject: TKMSubject) -> String {
         japanese = String(japanese.dropFirst(conjugationGroup.prefix.count))
       }
       if japanese.hasSuffix(conjugationGroup.suffix) {
-        japanese = String(japanese.dropLast(conjugationGroup.suffix.count))
+        if japanese != "する" {
+          japanese = String(japanese.dropLast(conjugationGroup.suffix.count))
+        }
       }
 
       patterns.append(japanese + conjugationGroup.pattern)


### PR DESCRIPTION
Hotfix for #636.

Added an additional if statement so app doesn't crash when する appears.

Issue before was that する is recognised as a `suruVerb`, but is omitted since it is a suffix. In the code, there is then an empty string, resulting in a crash. The above fix checks if it is the kana-word する, and then does NOT omit it.