### PR TITLE
Add ability to show minutes for upcoming level up review

### DIFF
--- a/ios/CurrentLevelReviewTimeItem.swift
+++ b/ios/CurrentLevelReviewTimeItem.swift
@@ -87,9 +87,11 @@ private func intervalString(_ date: Date) -> String {
                                 Calendar.Component.minute]
   var components = Calendar.current.dateComponents(componentsBitMask, from: Date(), to: date)
 
-  // Only show minutes after there are no hours left.
-  if let hour = components.hour, hour > 0 {
-    components.minute = 0
+  if !Settings.showMinutesForNextLevelUpReview {
+    // Only show minutes after there are no hours left.
+    if let hour = components.hour, hour > 0 {
+      components.minute = 0
+    }
   }
 
   return formatter.string(from: components)!

--- a/ios/ReviewSettingsViewController.swift
+++ b/ios/ReviewSettingsViewController.swift
@@ -85,6 +85,12 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
                              accessoryType: .disclosureIndicator,
                              target: self,
                              action: #selector(fontSizeChanged(_:))))
+    model.add(SwitchModelItem(style: .subtitle,
+                              title: "Show minutes for next level-up review",
+                              subtitle: nil,
+                              on: Settings.showMinutesForNextLevelUpReview,
+                              target: self,
+                              action: #selector(showMinutesForNextLevelUpReview(_:))))
 
     model.add(section: "Answers & marking")
     let keyboardSwitchItem = SwitchModelItem(style: .subtitle,
@@ -262,6 +268,10 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
 
   @objc private func showSRSLevelIndicatorSwitchChanged(_ switchView: UISwitch) {
     Settings.showSRSLevelIndicator = switchView.isOn
+  }
+
+  @objc private func showMinutesForNextLevelUpReview(_ switchView: UISwitch) {
+    Settings.showMinutesForNextLevelUpReview = switchView.isOn
   }
 
   @objc private func autoSwitchKeyboardSwitchChanged(_ switchView: UISwitch) {

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -189,6 +189,7 @@ protocol SettingProtocol {
   @Setting(true, #keyPath(showOldMnemonic)) static var showOldMnemonic: Bool
   @Setting(false, #keyPath(useKatakanaForOnyomi)) static var useKatakanaForOnyomi: Bool
   @Setting(false, #keyPath(showSRSLevelIndicator)) static var showSRSLevelIndicator: Bool
+  @Setting(false, #keyPath(showMinutesForNextLevelUpReview)) static var showMinutesForNextLevelUpReview: Bool
   @Setting(false, #keyPath(showAllReadings)) static var showAllReadings: Bool
   @Setting(false, #keyPath(autoSwitchKeyboard)) static var autoSwitchKeyboard: Bool
   @Setting(false, #keyPath(allowSkippingReviews)) static var allowSkippingReviews: Bool


### PR DESCRIPTION
The current default behavior of not showing minutes means that as a user I have to add the minutes on in my head. This setting removes that mental load if the user so desires.