### PR TITLE
Feature: Optional secondary review order sort by review subject type. 

### DIFF
--- a/ios/ReviewSettingsViewController.swift
+++ b/ios/ReviewSettingsViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2022 David Sansome
+// Copyright 2023 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,12 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
                              accessoryType: .disclosureIndicator,
                              target: self,
                              action: #selector(didTapReviewOrder(_:))))
+    model.add(BasicModelItem(style: .value1,
+                             title: "Subject Order",
+                             subtitle: secondaryReviewOrderValueText,
+                             accessoryType: .disclosureIndicator,
+                             target: self,
+                             action: #selector(didTapSecondaryReviewOrder(_:))))
     model.add(SwitchModelItem(style: .subtitle,
                               title: "Back-to-back",
                               subtitle: "Group Meaning and Reading together",
@@ -204,6 +210,10 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
     Settings.reviewOrder.description
   }
 
+  private var secondaryReviewOrderValueText: String {
+    Settings.secondaryReviewOrder.description
+  }
+
   private var taskOrderValueText: String {
     Settings.meaningFirst ? "Meaning first" : "Reading first"
   }
@@ -311,6 +321,13 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
     let vc = SettingChoiceListViewController(setting: Settings.$reviewOrder, title: "Review Order")
     vc.addChoicesFromEnum()
     navigationController?.pushViewController(vc, animated: true)
+  }
+
+  @objc private func didTapSecondaryReviewOrder(_: BasicModelItem) {
+    let vs = SettingChoiceListViewController(setting: Settings.$secondaryReviewOrder,
+                                             title: "Review Subject Order")
+    vs.addChoicesFromEnum()
+    navigationController?.pushViewController(vs, animated: true)
   }
 
   @objc private func didTapFonts(_: BasicModelItem) {

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -41,6 +41,28 @@ typealias SettingEnum = RawRepresentable & Codable & CaseIterable & CustomString
   }
 }
 
+@objc enum SecondaryReviewOrder: UInt, SettingEnum {
+  case unsorted = 1
+  case radicalKanjiVocabulary = 2 // (rkv)
+  case radicalVocabularyKanji = 3 // (rvk)
+  case kanjiRadicalVocabulary = 4 // (krv)
+  case kanjiVocabularyRadical = 5 // (kvr)
+  case vocabularyRadicalKanji = 6 // (vrk)
+  case vocabularyKanjiRadical = 7 // (vkr)
+
+  var description: String {
+    switch self {
+    case .unsorted: return "Unsorted"
+    case .radicalKanjiVocabulary: return "Radical, Kanji, Vocabulary"
+    case .radicalVocabularyKanji: return "Radical, Vocabulary, Kanji"
+    case .kanjiRadicalVocabulary: return "Kanji, Radical, Vocabulary"
+    case .kanjiVocabularyRadical: return "Kanji, Vocabulary, Radical"
+    case .vocabularyRadicalKanji: return "Vocabulary, Radical, Kanji"
+    case .vocabularyKanjiRadical: return "Vocabulary, Kanji, Radical"
+    }
+  }
+}
+
 @objc enum InterfaceStyle: UInt, SettingEnum {
   case system = 1
   case light = 2
@@ -176,6 +198,8 @@ protocol SettingProtocol {
   @Setting(true, #keyPath(showStatsSection)) static var showStatsSection: Bool
 
   @EnumSetting(ReviewOrder.random, #keyPath(reviewOrder)) static var reviewOrder: ReviewOrder
+  @EnumSetting(SecondaryReviewOrder.unsorted,
+               #keyPath(secondaryReviewOrder)) static var secondaryReviewOrder: SecondaryReviewOrder
   @Setting(5, #keyPath(reviewBatchSize)) static var reviewBatchSize: Int
   @Setting(Int.max, #keyPath(apprenticeLessonsLimit)) static var apprenticeLessonsLimit: Int
   @Setting(false, #keyPath(groupMeaningReading)) static var groupMeaningReading: Bool


### PR DESCRIPTION
This introduces an optional secondary review sort order by the review subject type (i.e. radical, kanji, vocabulary). The existing (unsorted) behavior is maintained by default.

Tested in simulator and via macOS Catalyst app.

I’m happy to make adjustments as you see fit. 😄 