### PR TITLE
Add 'Sounds' toggle for Notification Settings

### DIFF
--- a/ios/AppDelegate.swift
+++ b/ios/AppDelegate.swift
@@ -100,7 +100,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, LoginViewControllerDelega
     if !Screenshotter.isActive {
       // Ask for notification permissions.
       let unc = UNUserNotificationCenter.current()
-      unc.requestAuthorization(options: [.badge, .alert]) { _, _ in }
+      unc.requestAuthorization(options: [.badge, .alert, .sound]) { _, _ in }
     }
 
     let pushMainViewController = { () in
@@ -227,6 +227,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, LoginViewControllerDelega
           if settings.badgeSetting == .enabled, Settings.notificationsBadging {
             content.badge = NSNumber(value: cumulativeReviews)
           }
+          if settings.soundSetting == .enabled, Settings.notificationSounds {
+            content.sound = UNNotificationSound.default
+          }
+
           let trigger = UNTimeIntervalNotificationTrigger(timeInterval: triggerTimeInterval,
                                                           repeats: false)
           let request = UNNotificationRequest(identifier: identifier, content: content,

--- a/ios/AppSettingsViewController.swift
+++ b/ios/AppSettingsViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2022 David Sansome
+// Copyright 2023 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -66,6 +66,13 @@ class AppSettingsViewController: UITableViewController, TKMViewController {
                               target: self,
                               action: #selector(badgingSwitchChanged(_:))))
 
+    model.add(SwitchModelItem(style: .default,
+                              title: "Play sound with notifications",
+                              subtitle: nil,
+                              on: Settings.notificationSounds,
+                              target: self,
+                              action: #selector(soundSwitchChanged(_:))))
+
     self.model = model
     model.reloadTable()
   }
@@ -87,6 +94,12 @@ class AppSettingsViewController: UITableViewController, TKMViewController {
   @objc private func badgingSwitchChanged(_ switchView: UISwitch) {
     promptForNotifications(switchView: switchView) { granted in
       Settings.notificationsBadging = granted
+    }
+  }
+
+  @objc private func soundSwitchChanged(_ switchView: UISwitch) {
+    promptForNotifications(switchView: switchView) { granted in
+      Settings.notificationSounds = granted
     }
   }
 
@@ -120,7 +133,7 @@ class AppSettingsViewController: UITableViewController, TKMViewController {
       case .authorized, .provisional, .ephemeral:
         self.notificationHandler?(true)
       case .notDetermined:
-        center.requestAuthorization(options: [.badge, .alert]) { granted, _ in
+        center.requestAuthorization(options: [.badge, .alert, .sound]) { granted, _ in
           self.notificationHandler?(granted)
         }
       case .denied:

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -165,6 +165,7 @@ protocol SettingProtocol {
 
   @Setting(false, #keyPath(notificationsAllReviews)) static var notificationsAllReviews: Bool
   @Setting(true, #keyPath(notificationsBadging)) static var notificationsBadging: Bool
+  @Setting(true, #keyPath(notificationSounds)) static var notificationSounds: Bool
 
   @Setting(false, #keyPath(prioritizeCurrentLevel)) static var prioritizeCurrentLevel: Bool
   @EnumArraySetting([
@@ -189,7 +190,8 @@ protocol SettingProtocol {
   @Setting(true, #keyPath(showOldMnemonic)) static var showOldMnemonic: Bool
   @Setting(false, #keyPath(useKatakanaForOnyomi)) static var useKatakanaForOnyomi: Bool
   @Setting(false, #keyPath(showSRSLevelIndicator)) static var showSRSLevelIndicator: Bool
-  @Setting(false, #keyPath(showMinutesForNextLevelUpReview)) static var showMinutesForNextLevelUpReview: Bool
+  @Setting(false,
+           #keyPath(showMinutesForNextLevelUpReview)) static var showMinutesForNextLevelUpReview: Bool
   @Setting(false, #keyPath(showAllReadings)) static var showAllReadings: Bool
   @Setting(false, #keyPath(autoSwitchKeyboard)) static var autoSwitchKeyboard: Bool
   @Setting(false, #keyPath(allowSkippingReviews)) static var allowSkippingReviews: Bool


### PR DESCRIPTION
@davidsansome Implemented a new 'Sounds' toggle within the application's notification settings. When toggled, this feature will control the audible alerts for incoming notifications, providing users with a more customizable experience. This change ensures that our app aligns with common user expectations for notification management, enhancing overall usability.

Issue: #650 