### PR TITLE
Add ‘Critical Alerts’ and ‘Time Sensitive Notifications’ to Notifications

### DIFF
--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key></key>
+	<string></string>
+	<key>NSCriticalAlertsUsageDescription</key>
+	<string>We use critical alerts to notify you about urgent reviews.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/ios/ReviewContainerViewController.swift
+++ b/ios/ReviewContainerViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2022 David Sansome
+// Copyright 2023 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,6 +65,8 @@ class ReviewContainerViewController: MMDrawerController, ReviewViewControllerDel
 
   func finishedAllReviewItems(_ reviewViewController: ReviewViewController) {
     reviewViewController.performSegue(withIdentifier: "reviewSummary", sender: reviewViewController)
+    // Post a notification indicating that all reviews are complete
+    NotificationCenter.default.post(name: .reviewsCompleted, object: nil)
   }
 
   func allowsCustomFonts() -> Bool {

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -15,6 +15,9 @@
 import Foundation
 import WaniKaniAPI
 
+// Consts
+private let HALF_AN_HOUR_IN_SECONDS: Int = 1800
+
 typealias SettingEnum = RawRepresentable & Codable & CaseIterable & CustomStringConvertible
 
 @objc enum ReviewOrder: UInt, SettingEnum {
@@ -166,6 +169,14 @@ protocol SettingProtocol {
   @Setting(false, #keyPath(notificationsAllReviews)) static var notificationsAllReviews: Bool
   @Setting(true, #keyPath(notificationsBadging)) static var notificationsBadging: Bool
   @Setting(true, #keyPath(notificationSounds)) static var notificationSounds: Bool
+
+  // Critical Alerts setting - triggers an alert if reviews aren't done within the specified time frame, even if the phone is muted.
+  @Setting(true, #keyPath(criticalAlerts)) static var criticalAlerts: Bool
+  // Time Sensitive Notifications setting - triggers a notification if reviews aren't done within the specified time frame, even if Do Not Disturb is on.
+  @Setting(true,
+           #keyPath(timeSensitiveNotifications)) static var timeSensitiveNotifications: Bool
+  // Delay after which critical alerts and time-sensitive notifications are triggered.
+  @Setting(HALF_AN_HOUR_IN_SECONDS, #keyPath(notificationDelay)) static var notificationDelay: Int
 
   @Setting(false, #keyPath(prioritizeCurrentLevel)) static var prioritizeCurrentLevel: Bool
   @EnumArraySetting([


### PR DESCRIPTION
New feature:

Add ‘Critical Alerts’ and ‘Time Sensitive Notifications’ to Notifications - If you haven’t done your reviews within half an hour, even if your phone is muted or Do Not Disturb is on, you will be alerted, if the reviews are completed within the 30-minute window, then the ‘Time Sensitive Notifications’ will be canceled.

Attempt to add under the iPhone Settings App, under my App section, under the Notifications section, "Always Deliver Immediately" section, and under this section, there will be a ‘Critical Alerts' toggle option and there will be a 'Time Sensitive Notifications' toggle option.

Critical alerts appear on the Lock Screen and play a sound even if a Focus is on or iPhone is muted.