### PR TITLE
Add extra practice methods: recent mistakes, recent lessons, burned items

### DIFF
--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -370,6 +370,12 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
     }
   }
 
+  func getAllBurnedAssignments() -> [TKMAssignment] {
+    db.inDatabase { db in
+      getAllBurnedAssignments(transaction: db)
+    }
+  }
+
   private func getAllAssignments(transaction db: FMDatabase) -> [TKMAssignment] {
     var ret = [TKMAssignment]()
     for cursor in db.query("SELECT pb FROM assignments") {
@@ -388,6 +394,18 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
       "LEFT JOIN assignments AS a " +
       "ON p.id = a.subject_id " +
       "WHERE last_mistake_time >= \"\(formatter.string(from: dayAgo))\"") {
+      ret.append(cursor.proto(forColumnIndex: 0)!)
+    }
+    return ret
+  }
+
+  private func getAllBurnedAssignments(transaction db: FMDatabase) -> [TKMAssignment] {
+    var ret = [TKMAssignment]()
+    for cursor in db.query("SELECT a.pb " +
+      "FROM subject_progress AS p " +
+      "LEFT JOIN assignments AS a " +
+      "ON p.id = a.subject_id " +
+      "WHERE srs_stage >= \(SRSStage.burned.rawValue)") {
       ret.append(cursor.proto(forColumnIndex: 0)!)
     }
     return ret

--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -421,7 +421,7 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
       "FROM subject_progress AS p " +
       "LEFT JOIN assignments AS a " +
       "ON p.id = a.subject_id " +
-      "WHERE srs_stage >= \(SRSStage.burned.rawValue)") {
+      "WHERE srs_stage = \(SRSStage.burned.rawValue)") {
       ret.append(cursor.proto(forColumnIndex: 0)!)
     }
     return ret

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -167,7 +167,7 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
     let lessons = services.localCachingClient.availableLessonCount
     let reviews = services.localCachingClient.availableReviewCount
     let recentMistakes = services.localCachingClient.getRecentMistakesCount()
-    let recentLessons = services.localCachingClient.getAllRecentLessonAssignments()
+    let recentLessonCount = services.localCachingClient.recentLessonCount
     let upcomingReviews = services.localCachingClient.upcomingReviews
     let currentLevelAssignments = services.localCachingClient.getAssignmentsAtUsersCurrentLevel()
 
@@ -204,14 +204,14 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
         .add(createCurrentLevelReviewTimeItem(services: services,
                                               currentLevelAssignments: currentLevelAssignments))
 
-      if recentLessons.count > 0 {
+      if recentLessonCount > 0 {
         let recentLessonsItem = BasicModelItem(style: .value1,
                                                title: "Review recent lessons",
                                                subtitle: "",
                                                accessoryType: .disclosureIndicator,
                                                target: self,
                                                action: #selector(startRecentLessonReviews))
-        _ = setTableViewCellCount(recentLessonsItem, count: recentLessons.count)
+        _ = setTableViewCellCount(recentLessonsItem, count: recentLessonCount)
         model.add(recentLessonsItem)
       }
 

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -243,6 +243,15 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
     for category in SRSStageCategory.apprentice ... SRSStageCategory.burned {
       let count = services.localCachingClient.srsCategoryCounts[category.rawValue]
       model.add(SRSStageCategoryItem(stageCategory: category, count: Int(count)))
+      if category == SRSStageCategory.burned, count > 0 {
+        let reviewBurnedItem = BasicModelItem(style: .value1,
+                                              title: "Review burned items",
+                                              subtitle: "",
+                                              accessoryType: .disclosureIndicator,
+                                              target: self,
+                                              action: #selector(startBurnedItemReviews))
+        model.add(reviewBurnedItem)
+      }
     }
 
     self.model = model
@@ -341,7 +350,19 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
       }
 
       let vc = segue.destination as! ReviewContainerViewController
-      vc.setup(services: services, items: items, skipSendingProgress: true)
+      vc.setup(services: services, items: items, isPracticeSession: true)
+
+    case "startBurnedItemReviews":
+      let assignments = services.localCachingClient.getAllBurnedAssignments()
+      let items = ReviewItem.readyForBurnedReview(assignments: assignments,
+                                                  localCachingClient: services
+                                                    .localCachingClient)
+      if items.count == 0 {
+        return
+      }
+
+      let vc = segue.destination as! ReviewContainerViewController
+      vc.setup(services: services, items: items, isPracticeSession: true)
 
     case "startLessons":
       let assignments = services.localCachingClient.getAllAssignments()
@@ -612,6 +633,10 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
   @objc func startRecentMistakeReviews() {
     performSegue(withIdentifier: "startRecentMistakeReviews", sender: self)
+  }
+
+  @objc func startBurnedItemReviews() {
+    performSegue(withIdentifier: "startBurnedItemReviews", sender: self)
   }
 
   @objc func startLessons() {

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -166,6 +166,7 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
     let lessons = services.localCachingClient.availableLessonCount
     let reviews = services.localCachingClient.availableReviewCount
+    let recentMistakes = services.localCachingClient.getRecentMistakesCount()
     let upcomingReviews = services.localCachingClient.upcomingReviews
     let currentLevelAssignments = services.localCachingClient.getAssignmentsAtUsersCurrentLevel()
 
@@ -201,6 +202,17 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
       model
         .add(createCurrentLevelReviewTimeItem(services: services,
                                               currentLevelAssignments: currentLevelAssignments))
+
+      if recentMistakes > 0 {
+        let recentMistakesItem = BasicModelItem(style: .value1,
+                                                title: "Review recent mistakes",
+                                                subtitle: "",
+                                                accessoryType: .disclosureIndicator,
+                                                target: self,
+                                                action: #selector(startRecentMistakeReviews))
+        hasReviews = setTableViewCellCount(recentMistakesItem, count: recentMistakes)
+        model.add(recentMistakesItem)
+      }
     }
 
     if Settings.showPreviousLevelGraph, user.currentLevel > 1,
@@ -318,6 +330,18 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
       let vc = segue.destination as! ReviewContainerViewController
       vc.setup(services: services, items: items)
+
+    case "startRecentMistakeReviews":
+      let assignments = services.localCachingClient.getAllRecentMistakeAssignments()
+      let items = ReviewItem.readyForRecentMistakesReview(assignments: assignments,
+                                                          localCachingClient: services
+                                                            .localCachingClient)
+      if items.count == 0 {
+        return
+      }
+
+      let vc = segue.destination as! ReviewContainerViewController
+      vc.setup(services: services, items: items, skipSendingProgress: true)
 
     case "startLessons":
       let assignments = services.localCachingClient.getAllAssignments()
@@ -584,6 +608,10 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
   @objc func startReviews() {
     performSegue(withIdentifier: "startReviews", sender: self)
+  }
+
+  @objc func startRecentMistakeReviews() {
+    performSegue(withIdentifier: "startRecentMistakeReviews", sender: self)
   }
 
   @objc func startLessons() {

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -167,6 +167,7 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
     let lessons = services.localCachingClient.availableLessonCount
     let reviews = services.localCachingClient.availableReviewCount
     let recentMistakes = services.localCachingClient.getRecentMistakesCount()
+    let recentLessons = services.localCachingClient.getAllRecentLessonAssignments()
     let upcomingReviews = services.localCachingClient.upcomingReviews
     let currentLevelAssignments = services.localCachingClient.getAssignmentsAtUsersCurrentLevel()
 
@@ -203,6 +204,17 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
         .add(createCurrentLevelReviewTimeItem(services: services,
                                               currentLevelAssignments: currentLevelAssignments))
 
+      if recentLessons.count > 0 {
+        let recentLessonsItem = BasicModelItem(style: .value1,
+                                               title: "Review recent lessons",
+                                               subtitle: "",
+                                               accessoryType: .disclosureIndicator,
+                                               target: self,
+                                               action: #selector(startRecentLessonReviews))
+        _ = setTableViewCellCount(recentLessonsItem, count: recentLessons.count)
+        model.add(recentLessonsItem)
+      }
+
       if recentMistakes > 0 {
         let recentMistakesItem = BasicModelItem(style: .value1,
                                                 title: "Review recent mistakes",
@@ -210,7 +222,7 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
                                                 accessoryType: .disclosureIndicator,
                                                 target: self,
                                                 action: #selector(startRecentMistakeReviews))
-        hasReviews = setTableViewCellCount(recentMistakesItem, count: recentMistakes)
+        _ = setTableViewCellCount(recentMistakesItem, count: recentMistakes)
         model.add(recentMistakesItem)
       }
     }
@@ -345,6 +357,18 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
       let items = ReviewItem.readyForRecentMistakesReview(assignments: assignments,
                                                           localCachingClient: services
                                                             .localCachingClient)
+      if items.count == 0 {
+        return
+      }
+
+      let vc = segue.destination as! ReviewContainerViewController
+      vc.setup(services: services, items: items, isPracticeSession: true)
+
+    case "startRecentLessonReviews":
+      let assignments = services.localCachingClient.getAllRecentLessonAssignments()
+      let items = ReviewItem.readyForRecentLessonReview(assignments: assignments,
+                                                        localCachingClient: services
+                                                          .localCachingClient)
       if items.count == 0 {
         return
       }
@@ -633,6 +657,10 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
   @objc func startRecentMistakeReviews() {
     performSegue(withIdentifier: "startRecentMistakeReviews", sender: self)
+  }
+
+  @objc func startRecentLessonReviews() {
+    performSegue(withIdentifier: "startRecentLessonReviews", sender: self)
   }
 
   @objc func startBurnedItemReviews() {

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -266,6 +266,7 @@
                         <segue destination="MHj-tV-Wy7" kind="show" identifier="showAll" id="Gsa-0g-2hk"/>
                         <segue destination="HVF-EF-j9e" kind="show" identifier="settings" id="XTh-OI-gtz"/>
                         <segue destination="vBH-2Y-r3P" kind="show" identifier="tableForecast" id="XTh-OP-gtz"/>
+                        <segue destination="pOc-Ig-wgQ" kind="show" identifier="startRecentMistakeReviews" id="R3n-Ac-API"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dob-5V-x24" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -403,6 +404,9 @@
             <point key="canvasLocation" x="-1362" y="-493"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="R3n-Ac-API"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <image name="doc.on.clipboard" catalog="system" width="116" height="128"/>
         <image name="ic_search_white" width="24" height="24"/>

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -268,6 +268,7 @@
                         <segue destination="vBH-2Y-r3P" kind="show" identifier="tableForecast" id="XTh-OP-gtz"/>
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startRecentMistakeReviews" id="R3n-Ac-API"/>
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startBurnedItemReviews" id="kKg-5Q-7Ga"/>
+                        <segue destination="pOc-Ig-wgQ" kind="show" identifier="startRecentLessonReviews" id="Whr-8i-Twv"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dob-5V-x24" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -406,7 +407,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="kKg-5Q-7Ga"/>
+        <segue reference="Whr-8i-Twv"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="doc.on.clipboard" catalog="system" width="116" height="128"/>

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -267,6 +267,7 @@
                         <segue destination="HVF-EF-j9e" kind="show" identifier="settings" id="XTh-OI-gtz"/>
                         <segue destination="vBH-2Y-r3P" kind="show" identifier="tableForecast" id="XTh-OP-gtz"/>
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startRecentMistakeReviews" id="R3n-Ac-API"/>
+                        <segue destination="pOc-Ig-wgQ" kind="show" identifier="startBurnedItemReviews" id="kKg-5Q-7Ga"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dob-5V-x24" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -405,7 +406,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="R3n-Ac-API"/>
+        <segue reference="kKg-5Q-7Ga"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="doc.on.clipboard" catalog="system" width="116" height="128"/>

--- a/ios/ReviewContainerViewController.swift
+++ b/ios/ReviewContainerViewController.swift
@@ -20,13 +20,13 @@ class ReviewContainerViewController: MMDrawerController, ReviewViewControllerDel
   var services: TKMServices!
   var reviewVC: ReviewViewController!
 
-  func setup(services: TKMServices, items: [ReviewItem]) {
+  func setup(services: TKMServices, items: [ReviewItem], isPracticeSession: Bool = false) {
     self.services = services
 
     reviewVC = (storyboard!
       .instantiateViewController(withIdentifier: "reviewViewController") as! ReviewViewController)
     reviewVC.setup(services: services, items: items, showMenuButton: true, showSubjectHistory: true,
-                   delegate: self)
+                   delegate: self, isPracticeSession: isPracticeSession)
 
     let menuVC = storyboard!
       .instantiateViewController(withIdentifier: "reviewMenuViewController") as! ReviewMenuViewController

--- a/ios/ReviewItem.swift
+++ b/ios/ReviewItem.swift
@@ -65,6 +65,14 @@ class ReviewItem: NSObject {
     }
   }
 
+  class func readyForBurnedReview(assignments: [TKMAssignment],
+                                  localCachingClient: LocalCachingClient) -> [ReviewItem] {
+    filterReadyItems(assignments: assignments,
+                     localCachingClient: localCachingClient) { (assignment) -> Bool in
+      assignment.isBurned
+    }
+  }
+
   class func readyForLessons(assignments: [TKMAssignment],
                              localCachingClient: LocalCachingClient) -> [ReviewItem] {
     filterReadyItems(assignments: assignments,

--- a/ios/ReviewItem.swift
+++ b/ios/ReviewItem.swift
@@ -65,6 +65,14 @@ class ReviewItem: NSObject {
     }
   }
 
+  class func readyForRecentLessonReview(assignments: [TKMAssignment],
+                                        localCachingClient: LocalCachingClient) -> [ReviewItem] {
+    filterReadyItems(assignments: assignments,
+                     localCachingClient: localCachingClient) { (assignment) -> Bool in
+      assignment.isReviewStage
+    }
+  }
+
   class func readyForBurnedReview(assignments: [TKMAssignment],
                                   localCachingClient: LocalCachingClient) -> [ReviewItem] {
     filterReadyItems(assignments: assignments,

--- a/ios/ReviewItem.swift
+++ b/ios/ReviewItem.swift
@@ -57,6 +57,14 @@ class ReviewItem: NSObject {
     }
   }
 
+  class func readyForRecentMistakesReview(assignments: [TKMAssignment],
+                                          localCachingClient: LocalCachingClient) -> [ReviewItem] {
+    filterReadyItems(assignments: assignments,
+                     localCachingClient: localCachingClient) { (assignment) -> Bool in
+      assignment.isReviewStage && assignment.availableAtDate.timeIntervalSinceNow > 0
+    }
+  }
+
   class func readyForLessons(assignments: [TKMAssignment],
                              localCachingClient: LocalCachingClient) -> [ReviewItem] {
     filterReadyItems(assignments: assignments,

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -183,6 +183,8 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
   private var previousSubject: TKMSubject?
   private var previousSubjectLabel: UILabel?
 
+  private var skipSendingProgress = false
+
   // These are set to match the keyboard animation.
   private var animationDuration: Double = kDefaultAnimationDuration
   private var animationCurve: UIView.AnimationCurve = kDefaultAnimationCurve
@@ -231,13 +233,16 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
                     items: [ReviewItem],
                     showMenuButton: Bool,
                     showSubjectHistory: Bool,
-                    delegate: ReviewViewControllerDelegate) {
+                    delegate: ReviewViewControllerDelegate,
+                    skipSendingProgress: Bool = false) {
     self.services = services
     self.showMenuButton = showMenuButton
     self.showSubjectHistory = showSubjectHistory
     self.delegate = delegate
+    self.skipSendingProgress = skipSendingProgress
 
-    session = ReviewSession(services: services, items: items)
+    session = ReviewSession(services: services, items: items,
+                            forceGroupMeaningReading: skipSendingProgress)
   }
 
   public var activeQueueLength: Int {
@@ -1028,7 +1033,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     }
 
     // Mark the task.
-    var marked = session.markAnswer(result)
+    var marked = session.markAnswer(result, skipSendingProgress: skipSendingProgress)
 
     // Show a new task if it was correct.
     if result != .Incorrect {

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -183,7 +183,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
   private var previousSubject: TKMSubject?
   private var previousSubjectLabel: UILabel?
 
-  private var skipSendingProgress = false
+  private var isPracticeSession = false
 
   // These are set to match the keyboard animation.
   private var animationDuration: Double = kDefaultAnimationDuration
@@ -234,15 +234,15 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
                     showMenuButton: Bool,
                     showSubjectHistory: Bool,
                     delegate: ReviewViewControllerDelegate,
-                    skipSendingProgress: Bool = false) {
+                    isPracticeSession: Bool = false) {
     self.services = services
     self.showMenuButton = showMenuButton
     self.showSubjectHistory = showSubjectHistory
     self.delegate = delegate
-    self.skipSendingProgress = skipSendingProgress
+    self.isPracticeSession = isPracticeSession
 
     session = ReviewSession(services: services, items: items,
-                            forceGroupMeaningReading: skipSendingProgress)
+                            isPracticeSession: isPracticeSession)
   }
 
   public var activeQueueLength: Int {
@@ -1033,7 +1033,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     }
 
     // Mark the task.
-    var marked = session.markAnswer(result, skipSendingProgress: skipSendingProgress)
+    var marked = session.markAnswer(result, isPracticeSession: isPracticeSession)
 
     // Show a new task if it was correct.
     if result != .Incorrect {


### PR DESCRIPTION
This PR adds three new practice features to the app: review recent mistakes, review recent lessons, and review burned items.

### Practice: Review Recent Mistakes

Works like the website. You can review mistakes from the last 24 hours. Readings and meanings are grouped like on the website. This PR does not add the "redo lessons" feature like the website has.

Because [the API does not currently let you get review history](https://community.wanikani.com/t/api-changes-get-all-reviews/61617), however, this is only a local cache of recent mistakes. In theory, if/when that API comes back, this functionality will need to be updated/enhanced.

UI to get here is on the main screen and in the "Upcoming Reviews" section.

### Practice: Review Recent Lessons

Works like the website. You can review your recent lessons, review-style. Readings and meanings are grouped like on the website. The [definition of a "recent" lesson is found here](https://knowledge.wanikani.com/getting-started/extra-study/): 

> Any item you’ve learned in lessons and haven’t Guru’d in your reviews will be part of Recent Lessons mode. Once you complete your reviews and the item moves to the Guru stage, this will no longer remain in Recent Lessons.

UI to get here is on the main screen and in the "Upcoming Reviews" section (and above the recent mistakes review).

### Practice: Review Burned Items

Works like the website. You can review all your burned items review-style. Readings and meanings are grouped like on the website. I believe the WK website lets you practice all your burned items but doesn't repeat in between sessions until you have reviewed them all again. Right now, the app just throws all the burned items into a review session.

UI to get here is on the main screen all the way at the bottom under the "Burned" category.

### ~~Potential issue?~~

~~I think, for the practice sessions noted above, any changes to custom user data (custom meaning/reading explanation) aren't saved to the database. Am I reading the code correctly in that case? If so, this is probably a problem, since presumably a user might be using the explanation features when practicing recent mistakes. How should this best be solved? A refactor of `LocalCachingClient.sendProgress`? A new function to just save newer explanation data?~~ all is well, carry on.

### Fixes

* Fixes #672 
* Fixes #627 
* Fixes #446
