### PR TITLE
Fixes recent mistakes not sticking around after sync, cached #'s not being invalidated after logout/login

### DIFF
--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -1229,6 +1229,7 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
     }.ensure {
       self._availableSubjects.invalidate()
       self._srsCategoryCounts.invalidate()
+      self._recentLessonCount.invalidate()
       postNotificationOnMainQueue(.lccUserInfoChanged)
 
       self.busy = false
@@ -1241,6 +1242,12 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
       db.mustExecuteStatements(kClearAllData)
     }
     _maxLevelGrantedBySubscription.invalidate()
+    _pendingProgressCount.invalidate()
+    _availableSubjects.invalidate()
+    _srsCategoryCounts.invalidate()
+    _guruKanjiCount.invalidate()
+    _apprenticeCount.invalidate()
+    _recentLessonCount.invalidate()
   }
 
   func clearAllDataAndClose() {

--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -1236,6 +1236,7 @@ private func postNotificationOnMainQueue(_ notification: Notification.Name) {
     }
     _maxLevelGrantedBySubscription.invalidate()
     _pendingProgressCount.invalidate()
+    _pendingStudyMaterialsCount.invalidate()
     _availableSubjects.invalidate()
     _srsCategoryCounts.invalidate()
     _guruKanjiCount.invalidate()


### PR DESCRIPTION
My last PR, #674, had a small issue where recent mistakes were not sticking around in the database after an online assignment fetch due to `subject_progress` being wiped via a `REPLACE INTO` statement in `LocalCachingClient.fetchAssignments`. Instead of using `REPLACE INTO`, performs an `UPDATE` followed by an `INSERT` if the `UPDATE` did nothing.

Also fixes an issue I found where logging out of one account into another account without restarting the app didn't clear cached numbers in `LocalCachingClient`. Fixes this by invalidating items in `LocalCachingClient.clearAllData`. Also noticed that a force refresh would not clear the recent lesson count cached number from the web, so I also invalidated that on `sync`.

Closes #676 