### PR TITLE
Feature: Custom Gravatar email address

### DIFF
--- a/ios/AppSettingsViewController.swift
+++ b/ios/AppSettingsViewController.swift
@@ -19,6 +19,11 @@ class AppSettingsViewController: UITableViewController, TKMViewController {
   private var model: TableModel?
   private var notificationHandler: ((Bool) -> Void)?
 
+  private let kFontSize: CGFloat = {
+    let bodyFontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body)
+    return bodyFontDescriptor.pointSize
+  }()
+
   // MARK: - TKMViewController
 
   var canSwipeToGoBack: Bool { true }
@@ -51,6 +56,18 @@ class AppSettingsViewController: UITableViewController, TKMViewController {
                                target: self,
                                action: #selector(didTapInterfaceStyle(_:))))
     }
+
+    model.add(section: "User Data")
+    let gravatarItem =
+      EditableTextModelItem(text: NSAttributedString(string: Settings.gravatarCustomEmail),
+                            placeholderText: "Custom Gravatar email address",
+                            rightButtonImage: UIImage(named: "baseline_edit_black_24pt"),
+                            font: UIFont.systemFont(ofSize: kFontSize),
+                            autoCapitalizationType: .none)
+    gravatarItem.textChangedCallback = { (text: String) in
+      Settings.gravatarCustomEmail = text
+    }
+    model.add(gravatarItem)
 
     model.add(section: "Notifications")
     model.add(SwitchModelItem(style: .default,

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -558,7 +558,10 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
   func updateUserInfo() {
     guard let user = services.localCachingClient.getUserInfo() else { return }
-    let email = Settings.userEmailAddress
+    var email = Settings.userEmailAddress
+    if email.isEmpty {
+      email = Settings.gravatarCustomEmail
+    }
     let guruKanji = services.localCachingClient.guruKanjiCount
     let imageURL = email.isEmpty ? URL(string: kDefaultProfileImageURL)
       : userProfileImageURL(emailAddress: email)

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -209,6 +209,8 @@ protocol SettingProtocol {
   @Setting(false, #keyPath(offlineAudioCellular)) static var offlineAudioCellular: Bool
   @Setting([], #keyPath(offlineAudioVoiceActors)) static var offlineAudioVoiceActors: Set<Int64>
 
+  @Setting("", #keyPath(gravatarCustomEmail)) static var gravatarCustomEmail: String
+
   // Deprecated - remove after 1.24.
   @Setting([], #keyPath(installedAudioPackages)) static var installedAudioPackages: Set<String>
 

--- a/ios/Tables/EditableTextModelItem.swift
+++ b/ios/Tables/EditableTextModelItem.swift
@@ -17,13 +17,15 @@ import Foundation
 class EditableTextModelItem: AttributedModelItem {
   let placeholderText: String
   let font: UIFont
+  let autoCapitalizationType: UITextAutocapitalizationType
 
   var textChangedCallback: ((_ text: String) -> Void)?
 
   init(text: NSAttributedString, placeholderText: String, rightButtonImage: UIImage?,
-       font: UIFont) {
+       font: UIFont, autoCapitalizationType: UITextAutocapitalizationType = .sentences) {
     self.placeholderText = placeholderText
     self.font = font
+    self.autoCapitalizationType = autoCapitalizationType
     super.init(text: text)
 
     self.rightButtonImage = rightButtonImage
@@ -61,6 +63,7 @@ class EditableTextModelCell: AttributedModelCell, UITextViewDelegate {
     let item = baseItem as! EditableTextModelItem
 
     textView.font = item.font
+    textView.autocapitalizationType = item.autoCapitalizationType
     placeholderLabel.text = item.placeholderText
     placeholderLabel.font = item.font
     placeholderLabel.textColor = TKMStyle.Color.placeholderText


### PR DESCRIPTION
Allows the user to put in a custom Gravatar email address. Useful for API key users, as there is currently no other way to specify the email address used for Gravatar, and API key users don't get their email address pulled from the API. So unless a way to add a Gravatar email address is added, there is no way for API key users to get out of using the default avatar.

Also updates `EditableTextModelItem` to allow for custom auto capitalization rules as well so that the email isn't auto-capitalized.

![simulator_screenshot_A0C7FE5F-2F27-4DEE-BDDE-71C75E8284C3](https://github.com/davidsansome/tsurukame/assets/5092399/ec2237f2-2629-40bc-b26c-770787dfc5b1)

![simulator_screenshot_184B2F21-A306-44E6-AFB2-8745EBC801EC](https://github.com/davidsansome/tsurukame/assets/5092399/3093ad27-99da-442e-9584-164ced25df6c)
