### PR TITLE
Allow override of Gravatar with email/pass login

### DIFF
--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -565,10 +565,8 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
   func updateUserInfo() {
     guard let user = services.localCachingClient.getUserInfo() else { return }
-    var email = Settings.userEmailAddress
-    if email.isEmpty {
-      email = Settings.gravatarCustomEmail
-    }
+    let email = Settings.gravatarCustomEmail.isEmpty
+      ? Settings.userEmailAddress : Settings.gravatarCustomEmail
     let guruKanji = services.localCachingClient.guruKanjiCount
     let imageURL = email.isEmpty ? URL(string: kDefaultProfileImageURL)
       : userProfileImageURL(emailAddress: email)


### PR DESCRIPTION
Thanks for merging that last PR. After another test via TestFlight, everything works well. So, whether it was a weird caching fluke before (which we can now hopefully avoid that with a manual cache clear in the future), or if the SHA256 just works better on the Gravatar end for whatever reason, I'd call the problem "solved" and #635 can be closed as fixed. Left in the log statement for any future debugging that comes up.

This PR allows for the Gravatar override to also work for username/password logins instead of just API logins. Tested on simulator and device and it seems to work as expected. Hopefully this is the final Gravatar-related PR from me for a while.

(Apologies for all the PR's and activity last few days. Hope you don't mind. I do have one more minor bug fix for the "Recent Mistakes" feature planned for tomorrow when I can test it out more fully on my test account, but otherwise the new stuff seems to be working well.)