### PR TITLE
A few small UI fixes

### DIFF
--- a/ios/LoginViewController.swift
+++ b/ios/LoginViewController.swift
@@ -46,6 +46,10 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    if #available(iOS 13.0, *) {
+      overrideUserInterfaceStyle = .light
+    }
+
     TKMStyle.addShadowToView(signInLabel, offset: 0, opacity: 1, radius: 5)
     TKMStyle.addShadowToView(privacyPolicyLabel, offset: 0, opacity: 1, radius: 2)
     TKMStyle.addShadowToView(privacyPolicyButton, offset: 0, opacity: 1, radius: 2)

--- a/ios/LoginViewController.swift
+++ b/ios/LoginViewController.swift
@@ -127,8 +127,8 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         Settings.userApiToken = token
         Settings.userEmailAddress = ""
         self.delegate?.loginComplete()
-      }.catch { _ in
-        self.showLoginError("Invalid API token!")
+      }.catch { err in
+        self.showLoginError("Unable to login with API token! (\(err.localizedDescription))")
       }
     }
   }

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -95,7 +95,7 @@ private func attrString(_ string: String,
 
 private func defaultStringAttrs() -> [NSAttributedString.Key: Any] {
   [.foregroundColor: TKMStyle.Color.label,
-   .backgroundColor: TKMStyle.Color.cellBackground]
+   .backgroundColor: UIColor.clear]
 }
 
 private func dateFormatter(dateStyle: DateFormatter.Style,


### PR DESCRIPTION
* Actually show an error message to the user on API login failure instead of just "Invalid API token!"
* Force login view to be in light mode at all times. This one is subjective, I'll admit, but I'd like to argue that dark mode doesn't look good on the login screen, and I'm not sure making an entirely new UI for login for dark mode is worth the effort. See screenshots below. At the very least, this will make it look better for now until someone with more UI skills than I can improve it in dark mode.
* Fixes #578 by setting subject details background color to `UIColor.clear` rather than `TKMStyle.Color.cellBackground`. Why this is needed is unknown to me right now as the same color comes out of `TKMStyle.Color.cellBackground` on iOS vs macOS yet macOS needs the tweak. It doesn't hurt anything on iOS since the cell background is already set in the, well, cell, and yes, normal color changes/highlights (e.g. for readings/meanings) still work fine.

Light mode login:
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-01-02 at 11 57 36](https://github.com/davidsansome/tsurukame/assets/5092399/e71982a3-9484-48f6-90df-58dc200f2e10)
Dark mode login:
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-01-02 at 11 57 17](https://github.com/davidsansome/tsurukame/assets/5092399/f7678c16-3fe5-4629-bc49-7551f14787e4)


