### PR TITLE
Feature: Add lesson picker

### DIFF
--- a/ios/LessonPickerViewController.swift
+++ b/ios/LessonPickerViewController.swift
@@ -1,0 +1,149 @@
+// Copyright 2024 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+import Foundation
+import WaniKaniAPI
+
+class LessonPickerViewController: UITableViewController, SubjectDelegate {
+  var services: TKMServices!
+  private var model: TableModel?
+  private var reviewsBySubjectId: [Int64: ReviewItem] = [:]
+  private var selectedItems: [Int64: ReviewItem] = [:]
+
+  func setup(services: TKMServices) {
+    self.services = services
+  }
+
+  struct ReviewsForLevel {
+    var radicals: [SubjectModelItem]
+    var kanji: [SubjectModelItem]
+    var vocabulary: [SubjectModelItem]
+    init() {
+      radicals = []
+      kanji = []
+      vocabulary = []
+    }
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    navigationItem.title = "Lesson Picker"
+    navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Begin", style: .plain,
+                                                        target: self,
+                                                        action: #selector(startLessons))
+    navigationItem.rightBarButtonItem?.isEnabled = false // waiting for user to select items
+
+    let model = MutableTableModel(tableView: tableView)
+    model.add(section: "",
+              footer: "Select items below to queue them up for lessons. " +
+                "When you've finished selecting items, tap \"Begin\" " +
+                "in the top right to start.")
+    model.addSection()
+
+    let assignments = services.localCachingClient.getAllAssignments()
+    var items = ReviewItem.readyForLessons(assignments: assignments,
+                                           localCachingClient: services.localCachingClient)
+    items.sort { a, b in
+      a.assignment.level < b.assignment.level
+    }
+    var levels = [Int32: ReviewsForLevel]() // TODO: store arrays of radical/kanji/vocab
+    for reviewItem in items {
+      let assignment = reviewItem.assignment
+      guard let subject = services.localCachingClient.getSubject(id: assignment.subjectID)
+      else {
+        continue
+      }
+      reviewsBySubjectId[assignment.subjectID] = reviewItem
+
+      let item = SubjectModelItem(subject: subject, delegate: self, assignment: assignment,
+                                  readingWrong: false, meaningWrong: false)
+      item.showLevelNumber = true
+      item.showAnswers = false
+      item.showLevelNumber = false
+      item.canShowCheckmark = true
+      if levels.index(forKey: assignment.level) == nil {
+        levels[assignment.level] = ReviewsForLevel()
+      }
+      switch subject.subjectType {
+      case .radical:
+        levels[assignment.level]!.radicals.append(item)
+      case .kanji:
+        levels[assignment.level]!.kanji.append(item)
+      case .vocabulary:
+        levels[assignment.level]!.vocabulary.append(item)
+      default:
+        break
+      }
+    }
+
+    for (level, data) in levels {
+      model.add(section: "Level \(level)")
+      if !data.radicals.isEmpty {
+        model.add(TKMListSeparatorItem(label: "Radicals"))
+      }
+      for item in data.radicals {
+        model.add(item)
+      }
+      if !data.kanji.isEmpty {
+        model.add(TKMListSeparatorItem(label: "Kanji"))
+      }
+      for item in data.kanji {
+        model.add(item)
+      }
+      if !data.vocabulary.isEmpty {
+        model.add(TKMListSeparatorItem(label: "Vocabulary"))
+      }
+      for item in data.vocabulary {
+        model.add(item)
+      }
+    }
+    self.model = model
+  }
+
+  @objc func startLessons() {
+    performSegue(withIdentifier: "startCustomLessons", sender: self)
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    navigationController?.isNavigationBarHidden = false
+  }
+
+  override func prepare(for segue: UIStoryboardSegue, sender _: Any?) {
+    switch segue.identifier {
+    case "startCustomLessons":
+      if selectedItems.count == 0 {
+        return
+      }
+      let vc = segue.destination as! LessonsViewController
+      vc.setup(services: services, items: Array(selectedItems.values))
+    default:
+      break
+    }
+  }
+
+  // MARK: - SubjectDelegate
+
+  func didTapSubject(_ subject: TKMSubject) {
+    let hasItem = selectedItems.index(forKey: subject.id) != nil
+    if hasItem {
+      selectedItems.removeValue(forKey: subject.id)
+    } else {
+      selectedItems[subject.id] = reviewsBySubjectId[subject.id]
+    }
+    navigationItem.rightBarButtonItem?.isEnabled = selectedItems.count > 0
+  }
+}

--- a/ios/LessonPickerViewController.swift
+++ b/ios/LessonPickerViewController.swift
@@ -59,7 +59,7 @@ class LessonPickerViewController: UITableViewController, SubjectDelegate {
     items.sort { a, b in
       a.assignment.level < b.assignment.level
     }
-    var levels = [Int32: ReviewsForLevel]() // TODO: store arrays of radical/kanji/vocab
+    var levels = [Int32: ReviewsForLevel]()
     for reviewItem in items {
       let assignment = reviewItem.assignment
       guard let subject = services.localCachingClient.getSubject(id: assignment.subjectID)

--- a/ios/LessonPickerViewController.swift
+++ b/ios/LessonPickerViewController.swift
@@ -28,14 +28,9 @@ class LessonPickerViewController: UITableViewController, SubjectDelegate {
   }
 
   struct ReviewsForLevel {
-    var radicals: [SubjectModelItem]
-    var kanji: [SubjectModelItem]
-    var vocabulary: [SubjectModelItem]
-    init() {
-      radicals = []
-      kanji = []
-      vocabulary = []
-    }
+    var radicals: [SubjectModelItem] = []
+    var kanji: [SubjectModelItem] = []
+    var vocabulary: [SubjectModelItem] = []
   }
 
   override func viewDidLoad() {

--- a/ios/LessonPickerViewController.swift
+++ b/ios/LessonPickerViewController.swift
@@ -139,6 +139,8 @@ class LessonPickerViewController: UITableViewController, SubjectDelegate {
     } else {
       selectedItems[subject.id] = reviewsBySubjectId[subject.id]
     }
+    navigationItem.rightBarButtonItem?.title = selectedItems
+      .count > 0 ? "Begin (\(selectedItems.count))" : "Begin"
     navigationItem.rightBarButtonItem?.isEnabled = selectedItems.count > 0
   }
 }

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -191,6 +191,16 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
                                          disabledMessage: disabledMessage)
       model.add(lessonsItem)
 
+      if lessons > 0 && apprenticeCount < limit {
+        let lessonPickerItem = BasicModelItem(style: .value1,
+                                              title: "Lesson Picker",
+                                              subtitle: "",
+                                              accessoryType: .disclosureIndicator,
+                                              target: self,
+                                              action: #selector(showLessonPicker))
+        model.add(lessonPickerItem)
+      }
+
       let reviewsItem = BasicModelItem(style: .value1,
                                        title: "Reviews",
                                        subtitle: "",
@@ -420,6 +430,10 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
       let vc = segue.destination as! LessonsViewController
       vc.setup(services: services, items: items)
+
+    case "showLessonPicker":
+      let vc = segue.destination as! LessonPickerViewController
+      vc.setup(services: services)
 
     case "showAll":
       let vc = segue.destination as! SubjectCatalogueViewController
@@ -692,6 +706,10 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
 
   @objc func startLessons() {
     performSegue(withIdentifier: "startLessons", sender: self)
+  }
+
+  @objc func showLessonPicker() {
+    performSegue(withIdentifier: "showLessonPicker", sender: self)
   }
 
   @objc func showTableForecast() {

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Whd-2S-WNr">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Whd-2S-WNr">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -41,7 +41,7 @@
                                 <size key="shadowOffset" width="1" height="1"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ALW-Xn-F7M">
-                                <rect key="frame" x="67.5" y="274" width="240" height="119"/>
+                                <rect key="frame" x="67.5" y="284" width="240" height="119"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JYP-De-NXS">
                                         <rect key="frame" x="0.0" y="0.0" width="240" height="35"/>
@@ -105,7 +105,7 @@
                                 </constraints>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZdY-Fw-RIo">
-                                <rect key="frame" x="139.5" y="418.5" width="96" height="30"/>
+                                <rect key="frame" x="139.5" y="428.5" width="96" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <state key="normal" title="Use API token">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -197,16 +197,16 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Hq-bM-Oba" customClass="GradientView" customModule="Tsurukame" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="I7j-0Z-n8n">
-                                <rect key="frame" x="0.0" y="44" width="375" height="623"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <sections/>
                             </tableView>
                             <view alpha="0.0" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="uiT-6O-5H9" customClass="VacationModeView" customModule="Tsurukame" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44" width="375" height="100"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="100"/>
                                 <viewLayoutGuide key="safeArea" id="YkG-WD-iga"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
@@ -214,7 +214,7 @@
                                 </constraints>
                             </view>
                             <progressView opaque="NO" alpha="0.0" contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xYm-HJ-awB">
-                                <rect key="frame" x="0.0" y="44" width="375" height="4"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="4"/>
                             </progressView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ge9-QL-YFj"/>
@@ -270,6 +270,7 @@
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startBurnedItemReviews" id="kKg-5Q-7Ga"/>
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startRecentLessonReviews" id="Whr-8i-Twv"/>
                         <segue destination="lvd-2l-9te" kind="show" identifier="viewItemsInSrsCategory" id="h28-1t-bnp"/>
+                        <segue destination="dSL-HU-ltD" kind="show" identifier="showLessonPicker" id="CtZ-5U-qBu"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dob-5V-x24" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -358,7 +359,40 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9LG-MC-TeT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="546" y="176"/>
+            <point key="canvasLocation" x="504" y="108"/>
+        </scene>
+        <!--Lesson Picker View Controller-->
+        <scene sceneID="wa2-Sb-bdJ">
+            <objects>
+                <tableViewController id="dSL-HU-ltD" customClass="LessonPickerViewController" customModule="Tsurukame" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="Yw9-FI-HLy">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <connections>
+                            <outlet property="dataSource" destination="dSL-HU-ltD" id="lUK-aG-fps"/>
+                            <outlet property="delegate" destination="dSL-HU-ltD" id="Tuy-qz-8un"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="rL4-Vu-YuP"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <segue destination="cAb-cO-8UZ" kind="show" identifier="startCustomLessons" id="qUH-XI-g4x"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="88N-Oi-2D0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="910" y="361"/>
+        </scene>
+        <!--Lessons-->
+        <scene sceneID="Xg8-tU-lWu">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Lessons" id="cAb-cO-8UZ" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="FAz-2E-jQr"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="a6m-JG-BPx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1507" y="309"/>
         </scene>
         <!--subjectsRemaining-->
         <scene sceneID="kfs-vn-0Rb">
@@ -431,7 +465,7 @@
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ios/Tables/SubjectModelItem.swift
+++ b/ios/Tables/SubjectModelItem.swift
@@ -1,4 +1,4 @@
-// Copyright 2023 David Sansome
+// Copyright 2024 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ class SubjectModelItem: NSObject, TKMModelItem {
   var showAnswers = true
   var showRemaining = false
   var gradientColors: [Any]?
+  var canShowCheckmark = false
+  var isChecked = false
 
   init(subject: TKMSubject, delegate: SubjectDelegate, assignment: TKMAssignment? = nil,
        readingWrong: Bool = false, meaningWrong: Bool = false) {
@@ -57,12 +59,12 @@ class SubjectModelView: TKMModelCell {
     super.init(coder: coder)
     let gradientLayer = CAGradientLayer()
     gradient = gradientLayer
-    contentView.layer.insertSublayer(gradientLayer, at: 0)
+    layer.insertSublayer(gradientLayer, at: 0)
   }
 
   override func layoutSubviews() {
     super.layoutSubviews()
-    gradient?.frame = contentView.bounds
+    gradient?.frame = bounds
   }
 
   // MARK: - TKMModelCell
@@ -79,6 +81,12 @@ class SubjectModelView: TKMModelCell {
       levelLabel.text = "\(item.subject.level)"
     }
     updateGradient()
+    if item.canShowCheckmark && item.isChecked {
+      accessoryType = .checkmark
+    } else {
+      accessoryType = .none
+    }
+    tintColor = .white // for the checkmark
 
     subjectLabel.font = UIFont(name: TKMStyle.japaneseFontName, size: subjectLabel.font.pointSize)
     subjectLabel.attributedText = item.subject.japaneseText(imageSize: kJapaneseTextImageSize)
@@ -181,6 +189,12 @@ class SubjectModelView: TKMModelCell {
 
   override func didSelect() {
     if let item = item as? SubjectModelItem {
+      item.isChecked = !item.isChecked
+      if item.canShowCheckmark && item.isChecked {
+        accessoryType = .checkmark
+      } else {
+        accessoryType = .none
+      }
       item.delegate?.didTapSubject(item.subject)
     }
   }

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		63F7F52E23D4C2CA006A31FB /* Audio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F7F52D23D4C2CA006A31FB /* Audio.swift */; };
 		63FCAE78237F75CC00DB1418 /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FCAE77237F75CC00DB1418 /* Style.swift */; };
 		6F5E95176B5DCA719A6EED55 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 10E5709643045C62AD6AC427 /* Pods_Tests.framework */; };
+		79661CC22BAC117D003F8764 /* LessonPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79661CC12BAC117D003F8764 /* LessonPickerViewController.swift */; };
 		796706282B3BE71000CAF09B /* SubjectsByCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796706272B3BE71000CAF09B /* SubjectsByCategoryViewController.swift */; };
 		79D887452B41949F003D8F99 /* String+SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D887442B41949F003D8F99 /* String+SHA256.swift */; };
 		79D887472B419609003D8F99 /* String+SHA256Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D887462B419609003D8F99 /* String+SHA256Test.swift */; };
@@ -355,6 +356,7 @@
 		63FCAE77237F75CC00DB1418 /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
 		68B19C946E2F2284DA18EC3F /* Pods_Tsurukame__App_Store_screenshots_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tsurukame__App_Store_screenshots_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6978F17AB58C6447CED81564 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		79661CC12BAC117D003F8764 /* LessonPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonPickerViewController.swift; sourceTree = "<group>"; };
 		796706272B3BE71000CAF09B /* SubjectsByCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectsByCategoryViewController.swift; sourceTree = "<group>"; };
 		79D887442B41949F003D8F99 /* String+SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SHA256.swift"; sourceTree = "<group>"; };
 		79D887462B419609003D8F99 /* String+SHA256Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SHA256Test.swift"; sourceTree = "<group>"; };
@@ -530,6 +532,7 @@
 				639E750327E9CFB3006E36EA /* GradientView.swift */,
 				63EEFEC21FC45CB10070C05F /* Info.plist */,
 				639528FC25CC2F4F009845ED /* LessonOrderViewController.swift */,
+				79661CC12BAC117D003F8764 /* LessonPickerViewController.swift */,
 				630EB12025C5652400783E54 /* LessonsPageControl.swift */,
 				637CA11425D7E48A0082580E /* LessonsViewController.swift */,
 				631CAD6B234B2B60008CEA73 /* LevelTimeRemainingItem.swift */,
@@ -1322,6 +1325,7 @@
 				63C74BD125C82B1D004F6C99 /* SubjectCollectionModelItem.swift in Sources */,
 				63FCAE78237F75CC00DB1418 /* Style.swift in Sources */,
 				48F4B1DC268CB9850033860E /* UpcomingReviewsViewController.swift in Sources */,
+				79661CC22BAC117D003F8764 /* LessonPickerViewController.swift in Sources */,
 				63C74C7F25C96F58004F6C99 /* SubjectDelegate.swift in Sources */,
 				63D1026923D7ED3200838F7C /* UIWindow+InterfaceStyle.swift in Sources */,
 			);


### PR DESCRIPTION
Allows user to choose which lessons they want to do next. Based on feature from WK website. Lesson picker only shows up if user has available lessons and hasn't hit their apprentice count. Separates lessons by level and lesson type (radical vs kanji vs vocab).

Made some minor tweaks to the `SubjectModelItem` class to support using those types of cells with checkmarks. Added a new `LessonPickerViewController`. Other than that, pretty standard minor changes (new segues, main menu table cell item, etc.).

Note: Does not currently perform checks to see if user has selected more lessons to do than (current apprentice count + number of lessons selected to do).

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-03-21 at 19 17 46](https://github.com/davidsansome/tsurukame/assets/5092399/e20817b0-301f-4903-a807-19eb9cd80451)
