### PR TITLE
Fix macOS issue where text input gets highlighted during reviews

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -766,7 +766,6 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
       if ctx.cheats {
         addSynonymButton.isHidden = true
       }
-      answerField.becomeFirstResponder()
     }
 
     // This makes sure taps are still processed and not ignored, even when the closing animation


### PR DESCRIPTION
Fixes #706 
Related PR: #186  

[`becomeFirstResponder`](https://github.com/davidsansome/tsurukame/blob/ac4ed7f2261f772403d4b96bc7f8d18738e2744b/ios/ReviewViewController.swift#L769) was added in https://github.com/davidsansome/tsurukame/pull/186 to `ReviewViewController.animationDidStop` as a workaround specifically for macOS (starting at 10.15). At that time, the `answerTextField` would lose focus after each answer.

With current macOS (14.4), `answerTextField` no longer loses focus, but having the additional `becomeFirstResponder` triggered on `animationDidStop` causes the existing contents of `answerTextField` to be selected.

In my testing, the behavior of iOS on iPhone is not affected by this change either way.