### PR TITLE
Add counts to radical/kanji/vocab sections

### DIFF
--- a/ios/LessonPickerViewController.swift
+++ b/ios/LessonPickerViewController.swift
@@ -84,19 +84,19 @@ class LessonPickerViewController: UITableViewController, SubjectDelegate {
     for (level, data) in levels.sorted(by: { $0.key < $1.key }) {
       model.add(section: "Level \(level)")
       if !data.radicals.isEmpty {
-        model.add(TKMListSeparatorItem(label: "Radicals"))
+        model.add(TKMListSeparatorItem(label: "Radicals (\(data.radicals.count))"))
       }
       for item in data.radicals {
         model.add(item)
       }
       if !data.kanji.isEmpty {
-        model.add(TKMListSeparatorItem(label: "Kanji"))
+        model.add(TKMListSeparatorItem(label: "Kanji (\(data.kanji.count))"))
       }
       for item in data.kanji {
         model.add(item)
       }
       if !data.vocabulary.isEmpty {
-        model.add(TKMListSeparatorItem(label: "Vocabulary"))
+        model.add(TKMListSeparatorItem(label: "Vocabulary (\(data.vocabulary.count))"))
       }
       for item in data.vocabulary {
         model.add(item)

--- a/ios/SubjectsByCategoryViewController.swift
+++ b/ios/SubjectsByCategoryViewController.swift
@@ -75,19 +75,19 @@ class SubjectsByCategoryViewController: UITableViewController, SubjectDelegate {
     }
 
     if !radicals.isEmpty {
-      model.add(section: "Radicals")
+      model.add(section: "Radicals (\(radicals.count))")
       for item in radicals {
         model.add(item)
       }
     }
     if !kanji.isEmpty {
-      model.add(section: "Kanji")
+      model.add(section: "Kanji (\(kanji.count))")
       for item in kanji {
         model.add(item)
       }
     }
     if !vocabulary.isEmpty {
-      model.add(section: "Vocabulary")
+      model.add(section: "Vocabulary (\(vocabulary.count))")
       for item in vocabulary {
         model.add(item)
       }

--- a/ios/SubjectsByLevelViewController.swift
+++ b/ios/SubjectsByLevelViewController.swift
@@ -52,6 +52,9 @@ class SubjectsByLevelViewController: UITableViewController, SubjectDelegate {
       }
       model.add(item, toSection: section)
     }
+    model.sections[0].headerTitle! += " (\(model.sections[0].items.count))"
+    model.sections[1].headerTitle! += " (\(model.sections[1].items.count))"
+    model.sections[2].headerTitle! += " (\(model.sections[2].items.count))"
 
     let comparator = { (a: SubjectModelItem, b: SubjectModelItem) -> Bool in
       guard let aAssignment = a.assignment,

--- a/ios/SubjectsRemainingViewController.swift
+++ b/ios/SubjectsRemainingViewController.swift
@@ -74,19 +74,19 @@ class SubjectsRemainingViewController: UITableViewController, SubjectDelegate,
 
     let model = MutableTableModel(tableView: tableView)
     if !radicals.isEmpty {
-      model.add(section: "Radicals")
+      model.add(section: "Radicals (\(radicals.count))")
       for item in radicals {
         model.add(item)
       }
     }
     if !kanji.isEmpty {
-      model.add(section: "Kanji")
+      model.add(section: "Kanji (\(kanji.count))")
       for item in kanji {
         model.add(item)
       }
     }
     if !vocabulary.isEmpty {
-      model.add(section: "Vocabulary")
+      model.add(section: "Vocabulary (\(vocabulary.count))")
       for item in vocabulary {
         model.add(item)
       }


### PR DESCRIPTION
Added counts for radicals, kanji, and vocab on various screens so you can see how many items remain or are in the given section. This info is displayed on the WaniKani website when browsing things by level, and I think it would be useful in the app.

Added to the following screens:
- Lesson picker
- Number of items remaining in level
- Number of items in whole level
- Apprentice/guru/etc. lists

### Before

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-05 at 11 54 35](https://github.com/davidsansome/tsurukame/assets/5092399/5992544f-63ca-430a-a72d-c591fda015db)
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-05 at 11 55 08](https://github.com/davidsansome/tsurukame/assets/5092399/745dc689-8886-401a-a809-af00f7ae7435)


### After
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-05 at 11 52 27](https://github.com/davidsansome/tsurukame/assets/5092399/b0ca9f6c-68fa-4fdd-ad16-9ad386570f4c)
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-05 at 11 55 28](https://github.com/davidsansome/tsurukame/assets/5092399/b1f313e5-6a56-455e-a458-960ff91881ec)

