### PR TITLE
Bugfix: Fix lesson picker section text bleeding into nav bar

### DIFF
--- a/ios/LessonPickerViewController.swift
+++ b/ios/LessonPickerViewController.swift
@@ -46,7 +46,6 @@ class LessonPickerViewController: UITableViewController, SubjectDelegate {
               footer: "Select items below to queue them up for lessons. " +
                 "When you've finished selecting items, tap \"Begin\" " +
                 "in the top right to start.")
-    model.addSection()
 
     let assignments = services.localCachingClient.getAllAssignments()
     let items = ReviewItem.readyForLessons(assignments: assignments,

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -372,7 +372,7 @@
         <scene sceneID="wa2-Sb-bdJ">
             <objects>
                 <tableViewController id="dSL-HU-ltD" customClass="LessonPickerViewController" customModule="Tsurukame" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="Yw9-FI-HLy">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="Yw9-FI-HLy">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>


### PR DESCRIPTION
Finally figured out the difference between this and the `UpcomingReviewsViewController`: some properties on the table view sizing. Lesson picker now looks correct:

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-05 at 12 07 28](https://github.com/davidsansome/tsurukame/assets/5092399/10acfff3-a9a8-42ce-b2d3-9f18e2171494)

The removal of the `model.addSection()` in the lesson picker is not necessary for the fix; it just makes the UI look a little nicer.

Fixes #707