### PR TITLE
Adds swipe-to-go-back capability to the Apprentice, Guru, etc. categories.

### DIFF
--- a/ios/SubjectsByCategoryViewController.swift
+++ b/ios/SubjectsByCategoryViewController.swift
@@ -17,7 +17,7 @@ import Foundation
 import Foundation
 import WaniKaniAPI
 
-class SubjectsByCategoryViewController: UITableViewController, SubjectDelegate {
+class SubjectsByCategoryViewController: UITableViewController, SubjectDelegate, TKMViewController {
   private var services: TKMServices!
   private(set) var category: SRSStageCategory!
   private var showAnswers: Bool!
@@ -30,6 +30,12 @@ class SubjectsByCategoryViewController: UITableViewController, SubjectDelegate {
     self.showAnswers = showAnswers
     setShowAnswers(showAnswers, animated: false)
   }
+
+  // MARK: - TKMViewController
+
+  var canSwipeToGoBack: Bool { true }
+
+  // MARK: - UIViewController
 
   override func viewDidLoad() {
     super.viewDidLoad()


### PR DESCRIPTION
Very small change. Adds swipe-to-go-back capability to the Apprentice, Guru, Master, Enlightened, and Burned views via the SubjectsByCategoryViewController. This way it is in line with the "Show remaining" view (SubjectsRemainingViewController).