### PR TITLE
docs(settings):  add extended description for "Review Batch Size"

### DIFF
--- a/ios/ReviewSettingsViewController.swift
+++ b/ios/ReviewSettingsViewController.swift
@@ -358,9 +358,15 @@ func makeFontSizeViewController() -> UIViewController {
 }
 
 func makeReviewBatchSizeViewController() -> UIViewController {
+  let name = "Review Batch Size"
+  let description = "The \(name) setting is ONLY used when \"back-to-back\" reviews are disabled.\n\n" +
+    "When \"back-to-back\" reviews are disabled, you might be asked to review the meaning of an item and then " + 
+    "later after reviewing some other items, be asked to review the reading of that item. \nThe \(name) setting " + 
+    "controls the number of different review items you can encounter between reviewing the reading and " + 
+    "meaning for a given item."
   let vc = SettingChoiceListViewController(setting: Settings.$reviewBatchSize,
-                                           title: "Review Batch Size",
-                                           helpText: "Set the review queue size.")
+                                           title: name,
+                                           helpText: description)
   vc.addChoicesFromRange(3 ... 10, suffix: " reviews")
   return vc
 }


### PR DESCRIPTION
This is to address issue #745

adds extended description to the "review batch size" property to attempt to clear up confusion about what the setting actually does

the description I wrote is:

> The \(name) setting is ONLY used when "back-to-back" reviews are disabled.
>
> When "back-to-back" reviews are disabled, you might be asked to review the meaning of an item and then later after reviewing some other items, be asked to review the reading of that item.
> The \(name) setting controls the maximum number of different review items you can encounter between reviewing the reading and meaning for a given item."

<img width="521" alt="image" src="https://github.com/user-attachments/assets/b9c009f6-4272-4518-84cc-ddbd3f61a00a">