### PR TITLE
Deactivate audio session off main thread

### DIFF
--- a/ios/Audio.swift
+++ b/ios/Audio.swift
@@ -59,7 +59,9 @@ class Audio: NSObject {
       case .playing:
         try? session.setActive(true, options: [])
       case .finished:
-        try? session.setActive(false, options: [.notifyOthersOnDeactivation])
+        DispatchQueue.global().async {
+          try? session.setActive(false, options: [.notifyOthersOnDeactivation])
+        }
       default:
         break
       }


### PR DESCRIPTION
I noticed an issue of momentary UI/interactivity stutters happening at the end of vocabulary audio playback. The stuttering would cause dropped keystrokes on the on-screen keyboard, or incorrect words to be input when using the swipe keyboard.

To reproduce the stutter, have another app on the device currently using an audio session, and then do some reviews and make sure to try typing around the time the audio playback finishes. I noticed the stutter when on a voice call concurrently while doing reviews, but it may also happen with other audio session types.

I tracked this issue down to the `setActive(false, ...)` of the audio session which happens on the main thread, and I imagine it has to do with the `.notifyOthersOnDeactivation` option letting another app block the main thread.

Either way, I tried changing the audio session setActive to happen outside of the main thread, and with that change, I was no longer able to reproduce the stutter behavior on my local device.