### PR TITLE
feat(settings): conditionally hide "batch size"

### DIFF
--- a/ios/ReviewSettingsViewController.swift
+++ b/ios/ReviewSettingsViewController.swift
@@ -19,6 +19,7 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
   private var services: TKMServices!
   private var model: TableModel?
   private var groupMeaningReadingIndexPath: IndexPath?
+  private var nonBackToBackBatchSizeIndexPath: IndexPath?
   private var ankiModeCombineReadingMeaningIndexPath: IndexPath?
 
   func setup(services: TKMServices) {
@@ -63,12 +64,13 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
                                              },
                                              hidden:!Settings
                                                .groupMeaningReading)
-    model.add(BasicModelItem(style: .value1,
-                             title: "Batch size",
-                             subtitle: "\(Settings.reviewBatchSize.description)",
-                             accessoryType: .disclosureIndicator) { [unowned self] in self
-        .didTapReviewBatchSize()
-      })
+    nonBackToBackBatchSizeIndexPath = model.add(BasicModelItem(style: .value1,
+                                                               title: "Batch size",
+                                                               subtitle: "\(Settings.reviewBatchSize.description)",
+                                                               accessoryType: .disclosureIndicator) {
+                                                  [unowned self] in self.didTapReviewBatchSize()
+                                                },
+                                                hidden: Settings.groupMeaningReading)
 
     model.add(section: "Display")
     model.add(SwitchModelItem(style: .subtitle,
@@ -254,6 +256,9 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
     Settings.groupMeaningReading = switchView.isOn
     if let groupMeaningReadingIndexPath = groupMeaningReadingIndexPath {
       model?.setIndexPath(groupMeaningReadingIndexPath, hidden: !switchView.isOn)
+    }
+    if let nonBackToBackBatchSizeIndexPath = nonBackToBackBatchSizeIndexPath {
+      model?.setIndexPath(nonBackToBackBatchSizeIndexPath, hidden: switchView.isOn)
     }
   }
 


### PR DESCRIPTION
This is for #745 

Once this is merged in, it should be much more obvious that the "batch size" submenu settings controls something related to non-back-to-back reviews.

# If "back-to-back" is disabled
- the "back-to-back order" submenu is hidden (existing behavior)
- the "batch size" submenu is visible (existing behavior) 
<img width="519" alt="image" src="https://github.com/user-attachments/assets/eb16a2b1-6340-400d-a2f3-aeff57f2ea42">

# If "back-to-back" is enabled
- the "back-to-back order" submenu is visible (existing behavior)
- the "batch size" submenu is hidden (**new behavior**) 
<img width="514" alt="image" src="https://github.com/user-attachments/assets/044505e4-f0eb-410a-8408-460169d3d512">

