### PR TITLE
refactor(settings): rename 'batch size' property to be more descriptive

### DIFF
--- a/ios/ReviewSettingsViewController.swift
+++ b/ios/ReviewSettingsViewController.swift
@@ -16,6 +16,7 @@ import Foundation
 import UIKit
 
 class ReviewSettingsViewController: UITableViewController, TKMViewController {
+  static let NON_B2B_REVIEW_BATCH_SIZE_PROP_NAME = "Reviews Between Meaning & Reading"
   private var services: TKMServices!
   private var model: TableModel?
   private var groupMeaningReadingIndexPath: IndexPath?
@@ -65,7 +66,8 @@ class ReviewSettingsViewController: UITableViewController, TKMViewController {
                                              hidden:!Settings
                                                .groupMeaningReading)
     nonBackToBackBatchSizeIndexPath = model.add(BasicModelItem(style: .value1,
-                                                               title: "Batch size",
+                                                               title: ReviewSettingsViewController
+                                                                 .NON_B2B_REVIEW_BATCH_SIZE_PROP_NAME,
                                                                subtitle: "\(Settings.reviewBatchSize.description)",
                                                                accessoryType: .disclosureIndicator) {
                                                   [unowned self] in self.didTapReviewBatchSize()
@@ -363,11 +365,15 @@ func makeFontSizeViewController() -> UIViewController {
 }
 
 func makeReviewBatchSizeViewController() -> UIViewController {
-  let name = "Review Batch Size"
-  let description = "The \(name) setting is ONLY used when \"back-to-back\" reviews are disabled.\n\n" +
-    "When \"back-to-back\" reviews are disabled, you might be asked to review the meaning of an item and then " + 
-    "later after reviewing some other items, be asked to review the reading of that item. \nThe \(name) setting " + 
-    "controls the number of different review items you can encounter between reviewing the reading and " + 
+  let name = ReviewSettingsViewController.NON_B2B_REVIEW_BATCH_SIZE_PROP_NAME
+  let description =
+    "The \"\(name)\" setting is ONLY used when \"back-to-back\" reviews are disabled.\n\n" +
+    "When \"back-to-back\" reviews are disabled, you might be asked to review the meaning of an item and then " +
+
+    "later after reviewing some other items, be asked to review the reading of that item. \nThe \"\(name)\" setting " +
+
+    "controls the number of different review items you can encounter between reviewing the reading and " +
+
     "meaning for a given item."
   let vc = SettingChoiceListViewController(setting: Settings.$reviewBatchSize,
                                            title: name,


### PR DESCRIPTION
closes #745 

renames the 'review batch size' property to reflect the actual behavior that it controls so that it's more obvious to users what they're actually changing when they tweak this setting

I landed on `Reviews Between Meaning & Reading` which I feel is extremely descriptive, yet concise and clear. I don't see how you could misunderstand the behavior of this property now.

# Settings screen
<img width="519" alt="image" src="https://github.com/user-attachments/assets/7fbb3039-b556-45d7-99f8-465f6a2622fb">

# Settings detail screen
<img width="520" alt="image" src="https://github.com/user-attachments/assets/9fa94903-73ad-419e-8be4-a830b32c41ac">
