### PR TITLE
Fix text drawing for context sentence blurring

### DIFF
--- a/ios/Tables/AttributedModelItem.swift
+++ b/ios/Tables/AttributedModelItem.swift
@@ -44,7 +44,12 @@ class AttributedModelCell: TableModelCell {
     selectionStyle = .none
     isUserInteractionEnabled = true
 
-    textView = UITextView(frame: bounds)
+    if #available(iOS 16.0, *) {
+      textView = UITextView(usingTextLayoutManager: false)
+      textView.frame = bounds
+    } else {
+      textView = UITextView(frame: bounds)
+    }
     textView.isEditable = false
     textView.isScrollEnabled = false
     textView.textContainerInset = .zero
@@ -76,7 +81,7 @@ class AttributedModelCell: TableModelCell {
 
     // Calculate the height of the text. We can't just use UITextView.sizeThatFits because it gets
     // the wrong answer for CJK text. The order here matters, see
-    // https://github.com/facebook/AsyncDisplayKit/issues/2894.
+    // https://github.com/facebook/AsyncDisplayKit/issues/2894
     let storage = NSTextStorage()
     let manager = NSLayoutManager()
     manager.usesFontLeading = false

--- a/ios/Tables/ContextSentenceModelItem.swift
+++ b/ios/Tables/ContextSentenceModelItem.swift
@@ -93,8 +93,12 @@ private class ContextSentenceModelCell: AttributedModelCell {
       TKMStyle.Color.cellBackground.setFill()
       UIRectFill(rect)
       englishCtx.setAlpha(kBlurAlpha)
-      contextSentenceItem.englishText.draw(with: textView.frame, options: .usesLineFragmentOrigin,
-                                           context: nil)
+      // draw the full attributed string as displayed by the text view with Japanese as clear text
+      let mut = NSMutableAttributedString(attributedString: textView.attributedText)
+      mut.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.clear,
+                       range: NSRange(location: 0,
+                                      length: contextSentenceItem.japaneseText.length))
+      mut.draw(in: textView.frame)
     }
 
     // Blur the english text.


### PR DESCRIPTION
Closes #718
Closes #755 

It seems as though something is different in the way text is drawn in `ContextSentenceModelItem` and `AttributedModeltem` text measurement. Starting with iOS 16, `UITextView` changed its behavior for text layout. Reverting that change (to TextKit 1 layout) causes the Japanese text to draw the same for edge cases, but then the drawing in `ContextSentenceModelItem` is different.

To make it draw the same, grab the attributed string from the NSTextView and draw that instead. (The difference between the two attributed strings seems to be the font, interestingly enough, unless there is another attribute that I did not notice - I just checked via a simple print(), which may have skipped something).

So, said another way: The drawing in `ContextSentenceModelItem` draws different than the actual text layout in `AttributedModeltem`. In 生まれる, the first context sentence draws as 1 line in `ContextSentenceModelItem`, but 2 lines in `AttributedModeltem` via the actual `UITextView` (and for whatever reason the text height measurement is also only doing 1 line for the Japanese, making us 1 line short). We can make the `UITextView` draw the same way by forcing it to use TextKit 1 layout, but then the blurred text in `ContextSentenceModelItem` is not right, so we draw that text using the same attributed string as the `UITextView`, and things appear happy, even though I'm not exactly happy with this fix. But, I'd rather have something working than not working, even if it's ugly, since I'm not sure how to go about fixing this in the best way.

This is not the greatest fix in the world, I think, but it works on iOS 17 (SE 3 Simulator) and iOS 18 (SE 3 Simulator), and that is _something_ at least!

Test cases:
分
一台
二台
生まれ
生まれる
写る
足りない
交通
仮に
命
芸者
絵文字

All these test cases were broken before and are working now.

Before:
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-09-24 at 19 30 18](https://github.com/user-attachments/assets/cdbcf3e4-36ea-47d7-8c26-b8715e04d61c)
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-09-24 at 19 30 21](https://github.com/user-attachments/assets/42e6c131-28c8-48ae-9094-0dcd26374456)

Note the wrong placement of the English blur (as it is expecting 2 lines for the Japanese text, but the Japanese text only takes 1 line when drawn this way). But then, when you tap it, the `UITextView` is drawing with 2 lines for the Japanese. The English always needs 2 lines, but the text measuring only assumes 3 lines total instead of 4.

After:
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-09-24 at 19 31 08](https://github.com/user-attachments/assets/cfbe84be-3ef4-4b3a-b66c-ddb97a4857b6)
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-09-24 at 19 31 10](https://github.com/user-attachments/assets/78371ca9-3e4f-4fc4-83dd-af33107c5d26)

