### PR TITLE
Tweak header names for current/next level

### DIFF
--- a/ios/MainWaniKaniTabViewController.swift
+++ b/ios/MainWaniKaniTabViewController.swift
@@ -156,7 +156,7 @@ class MainWaniKaniTabViewController: UITableViewController {
        !services.localCachingClient.hasCompletedPreviousLevel() {
       let previousLevel = Int(user.currentLevel) - 1
       model
-        .add(section: "Prior level being completed (\(user.currentLevel - 1))")
+        .add(section: "Previous level (\(user.currentLevel - 1))")
       let currentGraphLevelAssignments = services.localCachingClient
         .getAssignments(level: previousLevel)
       model.add(CurrentLevelChartItem(currentLevelAssignments: currentGraphLevelAssignments))

--- a/ios/MainWaniKaniTabViewController.swift
+++ b/ios/MainWaniKaniTabViewController.swift
@@ -156,13 +156,13 @@ class MainWaniKaniTabViewController: UITableViewController {
        !services.localCachingClient.hasCompletedPreviousLevel() {
       let previousLevel = Int(user.currentLevel) - 1
       model
-        .add(section: "Current level (\(user.currentLevel - 1))")
+        .add(section: "Prior level being completed (\(user.currentLevel - 1))")
       let currentGraphLevelAssignments = services.localCachingClient
         .getAssignments(level: previousLevel)
       model.add(CurrentLevelChartItem(currentLevelAssignments: currentGraphLevelAssignments))
       addShowRemainingAllItems(model: model, level: previousLevel)
       // add header for next section; graph and other items will be added after this if/else block
-      model.add(section: "Next level (\(user.currentLevel))")
+      model.add(section: "Current level (\(user.currentLevel))")
     } else {
       model.add(section: "Current level")
     }

--- a/ios/SubjectDetailsSettingsViewController.swift
+++ b/ios/SubjectDetailsSettingsViewController.swift
@@ -62,8 +62,8 @@ class SubjectDetailsSettingsViewController: UITableViewController, TKMViewContro
     }
 
     model.add(SwitchModelItem(style: .subtitle,
-                              title: "Keep current level graph",
-                              subtitle: "Instead of showing the next level's graph when you finish the kanji for a given level, keep showing the same level completion graph until all radicals, kanji, and vocabulary have gotten to Guru or higher",
+                              title: "Show prior level graph until fully completed",
+                              subtitle: "When you finish the kanji for a given level, keep showing that level's completion graph until all radicals, kanji, and vocabulary have gotten to Guru or higher",
                               on: Settings.showPreviousLevelGraph,
                               switchHandler: levelGraphSwitchChanged))
 


### PR DESCRIPTION
The header names when showing your prior level graph have caused some confusion (see #622). This PR attempts to address those concerns by:

* Changing "Current Level (#)" (which is actually the prior level) to "Prior level being completed (#)"
* Changing "Next Level (#)" to the more intuitive "Current Level (#)", which will match the "Current Level" number everywhere else, including WaniKani's website
* Adjusting the settings text accordingly for clarity

**This is a text only change. Feedback and improvements to wording very welcome, but wanting to clean this up a bit.**