### PR TITLE
feat(reviews): batch size

### DIFF
--- a/ios/MainWaniKaniTabViewController.swift
+++ b/ios/MainWaniKaniTabViewController.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 David Sansome
+// Copyright 2025 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -231,10 +231,14 @@ class MainWaniKaniTabViewController: UITableViewController {
     switch StoryboardSegue.Main(segue) {
     case .startReviews:
       let assignments = services.localCachingClient.getAllAssignments()
-      let items = ReviewItem.readyForReview(assignments: assignments,
+      var items = ReviewItem.readyForReview(assignments: assignments,
                                             localCachingClient: services.localCachingClient)
       if items.count == 0 {
         return
+      }
+
+      if Settings.reviewItemsLimitEnabled && items.count > Settings.reviewItemsLimit {
+        items = Array(items[0 ..< Int(Settings.reviewItemsLimit)])
       }
 
       let vc = segue.destination as! ReviewContainerViewController

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 David Sansome
+// Copyright 2025 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -179,8 +179,10 @@ protocol SettingProtocol {
 
   @EnumSetting(ReviewOrder.random, #keyPath(reviewOrder)) static var reviewOrder: ReviewOrder
   @Setting(5, #keyPath(reviewBatchSize)) static var reviewBatchSize: Int
+  @Setting(15, #keyPath(reviewItemsLimit)) static var reviewItemsLimit: Int
   @Setting(Int.max, #keyPath(apprenticeLessonsLimit)) static var apprenticeLessonsLimit: Int
   @Setting(false, #keyPath(groupMeaningReading)) static var groupMeaningReading: Bool
+  @Setting(false, #keyPath(reviewItemsLimitEnabled)) static var reviewItemsLimitEnabled: Bool
   @Setting(true, #keyPath(meaningFirst)) static var meaningFirst: Bool
   @Setting(true, #keyPath(showAnswerImmediately)) static var showAnswerImmediately: Bool
   @Setting(false, #keyPath(showFullAnswer)) static var showFullAnswer: Bool


### PR DESCRIPTION
Issue #586 was opened as a "bug" because the review "batch size" property wasn't consistent with the lesson "batch size" property and as a result, created false expectations from users about what the app was supposed to do. Lesson batch size sets the number of items that appear in a lesson. Users expected review batch size to do the same thing for reviews, but in reality, controlled something else. #745 was implemented to alleviate the pain of this problem.

This PR implements a new feature that closes #586 because it provides the behavior that users were originally expecting from the review "batch size" property.

# Home screen (no change)
From my home screen you can see that I have 284 reviews to complete. This is existing behavior. No change
![01 base-reviews](https://github.com/user-attachments/assets/404002f7-87c1-495b-bae2-9f473771e8c4)

# Review screen (no change)
When I start doing reviews, I can see that the review queue at the top right shows how many reviews I have. It's that same 284 reviews from earlier. The app will continue doing reviews until I completely finish all 284.
![06 unlimited](https://github.com/user-attachments/assets/8a287784-98a6-4bb5-9014-58e0de5ec352)

# Review settings screen
In the review settings screen there is a new property called "review items in batches" that toggles on/off. The default value is OFF, making this feature an opt-in feature.
![02 new-setting](https://github.com/user-attachments/assets/a772b038-fe78-48b3-9dab-e66072536482)

# Review settings screen (with setting enabled)
When the new setting is enabled, another setting appears called "batch size." This is named consistently with the "batch size" setting in lesson settings.
![03 new-setting](https://github.com/user-attachments/assets/98c84803-05d4-470b-a762-6356f12cdf01)

# Review batch size
When you click on the batch size setting you will be prompted to select a batch size that you want. 
![04 new](https://github.com/user-attachments/assets/21e508a2-3f6c-4115-9cc7-f323891b66cc)

# Review screen (with batch size set)
Now if I go back to the review screen from earlier, I can see that the review queue size at the top right reflects the desired batch size. I still have 284 reviews in my entire queue, but this review session will only have me do 30 before the ending the session.
![05 limited](https://github.com/user-attachments/assets/4caaed88-d858-405f-8d8f-110a4eaa5482)
