### PR TITLE
fix(reviews): sort queue before truncating

### DIFF
--- a/ios/MainWaniKaniTabViewController.swift
+++ b/ios/MainWaniKaniTabViewController.swift
@@ -237,10 +237,6 @@ class MainWaniKaniTabViewController: UITableViewController {
         return
       }
 
-      if Settings.reviewItemsLimitEnabled && items.count > Settings.reviewItemsLimit {
-        items = Array(items[0 ..< Int(Settings.reviewItemsLimit)])
-      }
-
       let vc = segue.destination as! ReviewContainerViewController
       vc.setup(services: services, items: items)
 

--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 David Sansome
+// Copyright 2025 David Sansome
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ class ReviewSession {
     }
 
     sortReviewQueue()
+
+    if Settings.reviewItemsLimitEnabled, reviewQueue.count > Settings.reviewItemsLimit {
+      reviewQueue = Array(reviewQueue[0 ..< Int(Settings.reviewItemsLimit)])
+    }
+
     refillActiveQueue()
   }
 


### PR DESCRIPTION
I accidentally introduced a small bug in #797 where the review order isn't getting respected.

<img width="505" alt="Screenshot 2025-01-16 at 10 14 03 AM" src="https://github.com/user-attachments/assets/8c9ec192-04c0-484c-b66a-e69e4d299cb2" />

The reason for this is because the review queue starts off random, and I truncated the review queue in `ios/MainWaniKaniTabViewController.swift`, which then gets passed to `ios/ReviewSession.swift` where sorting happens. So long story short, I was truncating the queue BEFORE it got sorted. I updated the code to truncate after sorting and now everything is working as expected.