### PR TITLE
Add "Alternating SRS stage" review order

### DIFF
--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -277,7 +277,7 @@ class ReviewSession {
       var highest = false
       while (reviewQueue.count > 0) {
         alternatingReviewQueue.append(highest ? reviewQueue.removeLast() : reviewQueue.removeFirst())
-        highest = !highest;
+        highest = !highest
       }
       reviewQueue = alternatingReviewQueue
     case .random:

--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -265,6 +265,21 @@ class ReviewSession {
         if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
         return false
       }
+    case .alternatingSRSStage:
+      reviewQueue.sort { (a, b: ReviewItem) -> Bool in
+        if a.assignment.srsStage < b.assignment.srsStage { return true }
+        if a.assignment.srsStage > b.assignment.srsStage { return false }
+        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
+        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+        return false
+      }
+      var alternatingReviewQueue = [ReviewItem]()
+      var highest = false
+      while (reviewQueue.count > 0) {
+        alternatingReviewQueue.append(highest ? reviewQueue.removeLast() : reviewQueue.removeFirst())
+        highest = !highest;
+      }
+      reviewQueue = alternatingReviewQueue
     case .random:
       break
 

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -20,11 +20,12 @@ typealias SettingEnum = RawRepresentable & Codable & CaseIterable & CustomString
 @objc enum ReviewOrder: UInt, SettingEnum {
   case random = 1
   case ascendingSRSStage = 2
+  case descendingSRSStage = 7
+  case alternatingSRSStage = 9
   case currentLevelFirst = 3
   case lowestLevelFirst = 4
   case newestAvailableFirst = 5
   case oldestAvailableFirst = 6
-  case descendingSRSStage = 7
   case longestRelativeWait = 8
 
   var description: String {
@@ -37,6 +38,7 @@ typealias SettingEnum = RawRepresentable & Codable & CaseIterable & CustomString
     case .newestAvailableFirst: return "Newest available first"
     case .oldestAvailableFirst: return "Oldest available first"
     case .longestRelativeWait: return "Longest relative wait"
+    case .alternatingSRSStage: return "Alternating SRS stage"
     }
   }
 }


### PR DESCRIPTION
Adds a new review order called "Alternating SRS stage", which alternates reviews with the lowest and highest SRS stages.

For example, if the user has reviews with SRS stages `[1, 2, 3, 4, 5, 6, 7]`, then this option will present these reviews in the order `[1, 7, 2, 6, 3, 5, 4]`.

I've also reordered the enum entries to place all of the "SRS stage" options together, which should be a slight improvement to the UI. Previously, "Descending SRS stage" was near the bottom of the list while "Ascending SRS stage" was near the top.

<img width="627" alt="image" src="https://github.com/user-attachments/assets/084d521d-5773-4290-9ca3-ac9b5c408193" />
