### PR TITLE
Fix: Show API errors when account in hibernation

### DIFF
--- a/ios/CommonErrors.swift
+++ b/ios/CommonErrors.swift
@@ -1,0 +1,33 @@
+// Copyright 2025 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+class CommonErrors: NSObject {
+  static func getHibernatingAccountAlertController() -> UIAlertController {
+    let ac = UIAlertController(title: "Account is Hibernating",
+                               message: "Your WaniKani account is currently in hibernation mode for being inactive for too long. Please log into the WaniKani website to remove hibernation for your account.",
+                               preferredStyle: .alert)
+
+    ac.addAction(UIAlertAction(title: "Open WaniKani Website", style: .default,
+                               handler: { _ in
+                                 if let link =
+                                   URL(string: "https://www.wanikani.com") {
+                                   UIApplication.shared.open(link)
+                                 }
+                               }))
+    ac.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+    return ac
+  }
+}

--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -20,6 +20,7 @@ import WaniKaniAPI
 
 extension Notification.Name {
   static let lccUnauthorized = Notification.Name(rawValue: "lccUnauthorized")
+  static let lccHibernating = Notification.Name(rawValue: "lccHibernating")
   static let lccAvailableItemsChanged = Notification.Name("lccAvailableItemsChanged")
   static let lccPendingItemsChanged = Notification.Name("lccPendingItemsChanged")
   static let lccUserInfoChanged = Notification.Name("lccUserInfoChanged")
@@ -900,6 +901,17 @@ class LocalCachingClient: NSObject, SubjectLevelGetter {
       switch err.code {
       case 401:
         postNotificationOnMainQueue(.lccUnauthorized)
+      case 403:
+        // For hibernating acconts, message is: "403: The user is hibernating"
+        if (err.message?.contains("hibernating")) ?? false {
+          postNotificationOnMainQueue(.lccHibernating)
+        } else {
+          logError(code: err.code,
+                   description: err.message,
+                   request: err.request,
+                   response: err.response,
+                   responseData: nil)
+        }
 
       default:
         logError(code: err.code,

--- a/ios/LoginViewController.swift
+++ b/ios/LoginViewController.swift
@@ -120,12 +120,9 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
 
         self.delegate?.loginComplete()
       }.catch { error in
-        if let wkError = error as? WaniKaniAPI.WaniKaniWebClientError {
-          if wkError == .accountHibernating {
-            self.showHibernatingError()
-          } else {
-            self.showLoginError(error.localizedDescription)
-          }
+        if let wkError = error as? WaniKaniAPI.WaniKaniWebClientError,
+           wkError == .accountHibernating {
+          self.showHibernatingError()
         } else {
           self.showLoginError(error.localizedDescription)
         }
@@ -140,12 +137,9 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         Settings.userEmailAddress = ""
         self.delegate?.loginComplete()
       }.catch { err in
-        if let wkError = err as? WaniKaniAPIError {
-          if wkError.message?.contains("hibernating") ?? false {
-            self.showHibernatingError()
-          } else {
-            self.showLoginError("Unable to login with API token! (\(err.localizedDescription))")
-          }
+        if let wkError = err as? WaniKaniAPIError,
+           wkError.message?.contains("hibernating") ?? false {
+          self.showHibernatingError()
         } else {
           self.showLoginError("Unable to login with API token! (\(err.localizedDescription))")
         }

--- a/ios/LoginViewController.swift
+++ b/ios/LoginViewController.swift
@@ -120,7 +120,15 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
 
         self.delegate?.loginComplete()
       }.catch { error in
-        self.showLoginError(error.localizedDescription)
+        if let wkError = error as? WaniKaniAPI.WaniKaniWebClientError {
+          if wkError == .accountHibernating {
+            self.showHibernatingError()
+          } else {
+            self.showLoginError(error.localizedDescription)
+          }
+        } else {
+          self.showLoginError(error.localizedDescription)
+        }
       }
     } else {
       let token = apiTokenField.text!
@@ -132,7 +140,15 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         Settings.userEmailAddress = ""
         self.delegate?.loginComplete()
       }.catch { err in
-        self.showLoginError("Unable to login with API token! (\(err.localizedDescription))")
+        if let wkError = err as? WaniKaniAPIError {
+          if wkError.message?.contains("hibernating") ?? false {
+            self.showHibernatingError()
+          } else {
+            self.showLoginError("Unable to login with API token! (\(err.localizedDescription))")
+          }
+        } else {
+          self.showLoginError("Unable to login with API token! (\(err.localizedDescription))")
+        }
       }
     }
   }
@@ -174,6 +190,12 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
       self.present(c, animated: true, completion: nil)
       self.showActivityIndicatorOverlay(false)
     }
+  }
+
+  func showHibernatingError() {
+    present(CommonErrors.getHibernatingAccountAlertController(), animated: true,
+            completion: nil)
+    showActivityIndicatorOverlay(false)
   }
 
   func showActivityIndicatorOverlay(_ visible: Bool) {

--- a/ios/MainViewController.swift
+++ b/ios/MainViewController.swift
@@ -98,6 +98,7 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
     nd.add(name: .lccUserInfoChanged) { [weak self] _ in self?.userInfoChanged() }
     nd.add(name: .lccSRSCategoryCountsChanged) { [weak self] _ in self?.srsLevelCountsChanged() }
     nd.add(name: .lccUnauthorized) { [weak self] _ in self?.clientIsUnauthorized() }
+    nd.add(name: .lccHibernating) { [weak self] _ in self?.clientIsHibernating() }
     nd
       .add(name: UIApplication.didEnterBackgroundNotification) { [weak self] _ in
         self?.applicationDidEnterBackground()
@@ -377,6 +378,15 @@ class MainViewController: UIViewController, LoginViewControllerDelegate,
       self.loginAgain()
     }))
     present(ac, animated: true, completion: nil)
+  }
+
+  func clientIsHibernating() {
+    if isShowingUnauthorizedAlert {
+      return
+    }
+    isShowingUnauthorizedAlert = true
+
+    present(CommonErrors.getHibernatingAccountAlertController(), animated: true, completion: nil)
   }
 
   func loginAgain() {

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		63F7F52E23D4C2CA006A31FB /* Audio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F7F52D23D4C2CA006A31FB /* Audio.swift */; };
 		63FCAE78237F75CC00DB1418 /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FCAE77237F75CC00DB1418 /* Style.swift */; };
 		6F5E95176B5DCA719A6EED55 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 10E5709643045C62AD6AC427 /* Pods_Tests.framework */; };
+		791B8B5C2D657E2A000C8142 /* CommonErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791B8B5B2D657E2A000C8142 /* CommonErrors.swift */; };
 		79661CC22BAC117D003F8764 /* LessonPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79661CC12BAC117D003F8764 /* LessonPickerViewController.swift */; };
 		796706282B3BE71000CAF09B /* SubjectsByCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796706272B3BE71000CAF09B /* SubjectsByCategoryViewController.swift */; };
 		79D887452B41949F003D8F99 /* String+SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D887442B41949F003D8F99 /* String+SHA256.swift */; };
@@ -415,6 +416,7 @@
 		63FCAE77237F75CC00DB1418 /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
 		68B19C946E2F2284DA18EC3F /* Pods_Tsurukame__App_Store_screenshots_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tsurukame__App_Store_screenshots_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6978F17AB58C6447CED81564 /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		791B8B5B2D657E2A000C8142 /* CommonErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonErrors.swift; sourceTree = "<group>"; };
 		79661CC12BAC117D003F8764 /* LessonPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonPickerViewController.swift; sourceTree = "<group>"; };
 		796706272B3BE71000CAF09B /* SubjectsByCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectsByCategoryViewController.swift; sourceTree = "<group>"; };
 		79D887442B41949F003D8F99 /* String+SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SHA256.swift"; sourceTree = "<group>"; };
@@ -589,6 +591,7 @@
 				63F7F52D23D4C2CA006A31FB /* Audio.swift */,
 				631F34D62C36B7FE0071E983 /* BiggerTapAreaButton.swift */,
 				63344E7F2D291C9F002A4FED /* BuildConfigs */,
+				791B8B5B2D657E2A000C8142 /* CommonErrors.swift */,
 				C90846AD237F1C770068A272 /* Complication */,
 				C90846BC237F1C790068A272 /* ComplicationExtension */,
 				63CBFF2527731B8B0086BA5F /* DownloadViewController.swift */,
@@ -1451,6 +1454,7 @@
 				79D887452B41949F003D8F99 /* String+SHA256.swift in Sources */,
 				63344E8A2D291CAA002A4FED /* ReviewContainerViewController.swift in Sources */,
 				63344E8B2D291CAA002A4FED /* ReviewQuickSettingsAnswersMenu.swift in Sources */,
+				791B8B5C2D657E2A000C8142 /* CommonErrors.swift in Sources */,
 				63344E8C2D291CAA002A4FED /* ReviewQuickSettingsAudioMenu.swift in Sources */,
 				63344E8D2D291CAA002A4FED /* ReviewQuickSettingsDisplayMenu.swift in Sources */,
 				63344E8E2D291CAA002A4FED /* ReviewQuickSettingsMenu.swift in Sources */,

--- a/ios/WaniKaniAPI/Sources/WaniKaniAPI/WebClient.swift
+++ b/ios/WaniKaniAPI/Sources/WaniKaniAPI/WebClient.swift
@@ -19,6 +19,7 @@ import PromiseKit
 public enum WaniKaniWebClientError: Int, LocalizedError {
   case csrfTokenNotFound
   case apiTokenNotFound
+  case accountHibernating
   case emailNotFound
   case sessionCookieNotSet
   case badCredentials
@@ -36,6 +37,8 @@ public enum WaniKaniWebClientError: Int, LocalizedError {
       return "Session cookie not set"
     case .badCredentials:
       return "Incorrect email or password"
+    case .accountHibernating:
+      return "Account is in hibernation mode"
     default:
       return "Unknown error"
     }
@@ -150,6 +153,9 @@ public class WaniKaniWebClient {
     }.map { arg throws -> String in
       if let apiToken = self.extractApiToken(arg.data) {
         return apiToken
+      }
+      if arg.response.url?.absoluteString.contains("hibernation") ?? false {
+        throw WaniKaniWebClientError.accountHibernating
       }
       throw WaniKaniWebClientError.apiTokenNotFound
     }


### PR DESCRIPTION
Currently, no error is shown when accounts are in hibernation. This PR shows errors on the main screen and on login (for both username/password and API token) when the account is in hibernation. I don't think we can handle this for the user, so this points the user to the WaniKani website to fix the problem.

Screen shown on website when in hibernation:
<img width="600" alt="Screenshot 2025-02-19 at 11 44 41 AM" src="https://github.com/user-attachments/assets/a74ba9c3-44dc-49fa-998a-5a677c169cb8" />

What the app shows (this is the login screen but same idea if already logged in):
![Simulator Screenshot - iPhone SE (3rd generation) - 2025-02-19 at 12 05 09](https://github.com/user-attachments/assets/ad707ed7-ec6f-4887-8854-a414bd75ea3a)

Fixes #767