### PR TITLE
Fix bug: Typing in not-latest position in TKMKanaInput moves caret to end

### DIFF
--- a/ios/TKMKanaInput.m
+++ b/ios/TKMKanaInput.m
@@ -403,10 +403,12 @@ NSString *TKMConvertKanaText(NSString *input) {
         [kConsonants characterIsMember:newChar] && [kConsonants characterIsMember:lastChar]) {
       NSString *replacementString =
           (lastCharWasUppercase || _alphabet == kTKMAlphabetKatakana) ? @"ッ" : @"っ";
+      UITextRange *beforeChangeRange = textField.selectedTextRange;
       textField.text =
           [textField.text stringByReplacingCharactersInRange:NSMakeRange(range.location - 1, 1)
                                                   withString:replacementString];
       [textField setTextAlignment:NSTextAlignmentCenter];
+      textField.selectedTextRange = beforeChangeRange;
 
       return YES;
     }
@@ -416,10 +418,12 @@ NSString *TKMConvertKanaText(NSString *input) {
         ![kCanFollowN characterIsMember:newChar]) {
       NSString *replacementString =
           (lastCharWasUppercase || _alphabet == kTKMAlphabetKatakana) ? @"ン" : @"ん";
+      UITextRange *beforeChangeRange = textField.selectedTextRange;
       textField.text =
           [textField.text stringByReplacingCharactersInRange:NSMakeRange(range.location - 1, 1)
                                                   withString:replacementString];
       [textField setTextAlignment:NSTextAlignmentCenter];
+      textField.selectedTextRange = beforeChangeRange;
 
       return YES;
     }
@@ -447,6 +451,15 @@ NSString *TKMConvertKanaText(NSString *input) {
       textField.text = [textField.text stringByReplacingCharactersInRange:replacementRange
                                                                withString:replacement];
       [textField setTextAlignment:NSTextAlignmentCenter];
+      // range is before the new letter is typed, so it is off by 1 from where it would be if we
+      // made no changes, so we add in 1 again for the new final position
+      NSUInteger updatedPosition = text.length > replacement.length
+                                       ? range.location - (text.length - replacement.length) + 1
+                                       : range.location + 1;
+      UITextPosition *updatedTextPosition =
+          [textField positionFromPosition:textField.beginningOfDocument offset:updatedPosition];
+      textField.selectedTextRange = [textField textRangeFromPosition:updatedTextPosition
+                                                          toPosition:updatedTextPosition];
 
       return NO;
     }


### PR DESCRIPTION
When doing reviews, when you are typing at the end of the text field, all is well. However, if you make a mistake and go back to fix it, as soon as the text is transformed (say `ku` to `く`), the cursor auto-shifts to the end due to the text replacement in `TKMKanaInput`.

This PR fixes that by fixing the selection after the text has been changed.

Some GIFs for demonstration. (Not perfect GIF recordings, but they should give you the idea.)

Before:
![before](https://github.com/user-attachments/assets/89888f5c-c1ed-4e87-af87-a7b33b6130ad)

After:
![after](https://github.com/user-attachments/assets/de67cdef-d883-4942-aa7d-87c3278668b0)

Fixes #743

