### PR TITLE
Allow user to practice apprentice leech items

### DIFF
--- a/ios/Generated/IB-Segues+Generated.swift
+++ b/ios/Generated/IB-Segues+Generated.swift
@@ -25,6 +25,7 @@ internal enum StoryboardSegue {
     case showAll
     case showLessonPicker
     case showRemaining
+    case startAlreadyPassedApprenticeReviews
     case startBurnedItemReviews
     case startLessons
     case startRecentLessonReviews

--- a/ios/MainWaniKaniTabViewController.swift
+++ b/ios/MainWaniKaniTabViewController.swift
@@ -150,6 +150,21 @@ class MainWaniKaniTabViewController: UITableViewController {
         _ = setTableViewCellCount(recentMistakesItem, count: recentMistakes)
         model.add(recentMistakesItem)
       }
+
+      let alreadyPassedButApprenticeCount = apprenticeCount - recentLessonCount
+      if alreadyPassedButApprenticeCount > 0 {
+        let alreadyPassedApprenticeItem = BasicModelItem(style: .value1,
+                                                         title: "Review apprentice leeches",
+                                                         subtitle: "",
+                                                         accessoryType: .disclosureIndicator) { [
+          unowned self
+        ] in
+          self.startAlreadyPassedApprenticeReviews()
+        }
+        _ = setTableViewCellCount(alreadyPassedApprenticeItem,
+                                  count: alreadyPassedButApprenticeCount)
+        model.add(alreadyPassedApprenticeItem)
+      }
     }
 
     if Settings.showPreviousLevelGraph, user.currentLevel > 1,
@@ -257,6 +272,20 @@ class MainWaniKaniTabViewController: UITableViewController {
       let items = ReviewItem.readyForRecentLessonReview(assignments: assignments,
                                                         localCachingClient: services
                                                           .localCachingClient)
+      if items.count == 0 {
+        return
+      }
+
+      let vc = segue.destination as! ReviewContainerViewController
+      vc.setup(services: services, items: items, isPracticeSession: true)
+
+    case .startAlreadyPassedApprenticeReviews:
+      // load apprentice items, then keep the ones that have been passed.
+      let apprenticeItems = services.localCachingClient
+        .getAssignmentsInCategory(category: SRSStageCategory.apprentice)
+      let items = ReviewItem.readyForAlreadyPassedApprenticeReview(assignments: apprenticeItems,
+                                                                   localCachingClient: services
+                                                                     .localCachingClient)
       if items.count == 0 {
         return
       }
@@ -377,6 +406,10 @@ class MainWaniKaniTabViewController: UITableViewController {
 
   @objc func startRecentLessonReviews() {
     perform(segue: StoryboardSegue.Main.startRecentLessonReviews, sender: self)
+  }
+
+  @objc func startAlreadyPassedApprenticeReviews() {
+    perform(segue: StoryboardSegue.Main.startAlreadyPassedApprenticeReviews, sender: self)
   }
 
   @objc func startBurnedItemReviews() {

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -52,6 +52,7 @@
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startBurnedItemReviews" id="p5M-1d-3JR"/>
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startRecentMistakeReviews" id="k4i-e6-YJX"/>
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startReviews" id="SNd-yz-wla"/>
+                        <segue destination="pOc-Ig-wgQ" kind="show" identifier="startAlreadyPassedApprenticeReviews" id="Zly-NW-0bf"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="kbL-0E-6LB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -256,7 +257,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="AxF-9f-jjW"/>
+        <segue reference="Zly-NW-0bf"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="ic_search_white" width="24" height="24"/>

--- a/ios/ReviewItem.swift
+++ b/ios/ReviewItem.swift
@@ -73,6 +73,15 @@ class ReviewItem: NSObject {
     }
   }
 
+  class func readyForAlreadyPassedApprenticeReview(assignments: [TKMAssignment],
+                                                   localCachingClient: LocalCachingClient)
+    -> [ReviewItem] {
+    filterReadyItems(assignments: assignments,
+                     localCachingClient: localCachingClient) { assignment -> Bool in
+      assignment.hasPassedAt && assignment.srsStage < .guru1
+    }
+  }
+
   class func readyForBurnedReview(assignments: [TKMAssignment],
                                   localCachingClient: LocalCachingClient) -> [ReviewItem] {
     filterReadyItems(assignments: assignments,


### PR DESCRIPTION
These are items that have been guru'd but have fallen back to the apprentice SRS stage. Not exactly leeches (based on definitions on the forums such as https://community.wanikani.com/t/userscript-wanikani-open-framework-additional-filters-recent-lessons-leech-training-related-items-and-more/30512), but this will at least help some users that keep failing some items (namely, me, myself, and I).

The steps to make actual leech training available would touch a greater part of the codebase, as we'd have to update the API pulls to get review stats and then make use of that when filtering for leeches, along with at least one setting for the math formula for calculating what a leech is. This PR at least helps users who continuously guru -> apprentice -> guru -> apprentice items. (Yes, I'm guilty of that for some items!)

Related: #332