### PR TITLE
Fix red text highlighting issue in reviews

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -978,11 +978,12 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     submitButton.isEnabled = Settings.allowSkippingReviews || Settings.ankiMode || !text.isEmpty
   }
 
-  func textField(_: UITextField, shouldChangeCharactersIn _: NSRange,
+  func textField(_ field: UITextField, shouldChangeCharactersIn _: NSRange,
                  replacementString _: String) -> Bool {
     DispatchQueue.main.async {
       self.answerFieldValueDidChange()
     }
+    field.typingAttributes = [:]
     return true
   }
 


### PR DESCRIPTION
After getting a shake and red letters, sometimes the full text would change red after making further changes despite changing the full text in TKMInput. Removing typing attributes fixes that. (The attributes were somehow carrying over into the full string when replacing text, likely because of where the user's cursor was, so removing those typing attributes removes the attributes moving into the full string.)

A reliable way to replicate is by going to a review for 分ける, typing `わけry`, hitting enter, erasing `y`, then typing. All text turns red.

Done in ReviewViewController since that's where the highlighting is done in the first place.

See also: https://stackoverflow.com/questions/34689141

Before:
![before](https://github.com/user-attachments/assets/1669e526-f4dd-482b-bb53-abae333b9e96)

After:
![after](https://github.com/user-attachments/assets/ef6e895c-3b9f-46fa-8f17-fde77e3e3904)

(P.S. Test builds are failing to publish right now; is there some new apple agreement that needs to be agreed to or something? GitHub Actions isn't listing the error publicly.)