### PR TITLE
Fix bug: Retain center text when replacing typing attributes

### DIFF
--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -983,7 +983,9 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     DispatchQueue.main.async {
       self.answerFieldValueDidChange()
     }
-    field.typingAttributes = [:]
+    let style = NSMutableParagraphStyle()
+    style.alignment = NSTextAlignment.center
+    field.typingAttributes = [.paragraphStyle: style]
     return true
   }
 


### PR DESCRIPTION
#813 broke text alignment in certain cases. Sorry about that. Replicate by typing any hiragana or three, then select all, then type again -> alignment goes to left. (Why removing typing attributes breaks the center text alignment set on the overall field is unknown to me.)

This PR fixes it by making sure to retain the text alignment in the typing attributes, which retains the center alignment when typing.