### PR TITLE
Fix TKMInput single char input with range.length>0

### DIFF
--- a/ios/TKMKanaInput+Internals.h
+++ b/ios/TKMKanaInput+Internals.h
@@ -20,6 +20,7 @@ static const unichar kHiraganaMax = u'\u309f';
 static const unichar kHiraganaMin = u'\u3040';
 
 static NSDictionary<NSString *, NSString *> *kReplacements;
+static NSCharacterSet *kVowels;
 static NSCharacterSet *kConsonants;
 static NSCharacterSet *kN;
 static NSCharacterSet *kCanFollowN;


### PR DESCRIPTION
Makes it so that single char (e.g. `a` to `あ`) works properly when `range.length > 0` in `TKMInput`. Implemented this in its own `if` case just to keep things straightforward without potentially messing up some other parts of the text replacement code.

See #744 for wrong behavior and the following GIF for the new behavior:

![text-replace](https://github.com/user-attachments/assets/bf5c5141-e7a1-4dea-ab94-f48ed982b43a)

Also fixes a code style issue where `[textField setTextAlignment:NSTextAlignmentCenter];` should be `textField.textAlignment = NSTextAlignmentCenter;`.

Closes #744


