### PR TITLE
fix(reviews): sort queue when building session

### DIFF
--- a/ios/MainWaniKaniTabViewController.swift
+++ b/ios/MainWaniKaniTabViewController.swift
@@ -261,10 +261,17 @@ class MainWaniKaniTabViewController: UITableViewController {
     switch StoryboardSegue.Main(segue) {
     case .startReviews:
       let assignments = services.localCachingClient.getAllAssignments()
-      let items = ReviewItem.readyForReview(assignments: assignments,
+      var items = ReviewItem.readyForReview(assignments: assignments,
                                             localCachingClient: services.localCachingClient)
       if items.count == 0 {
         return
+      }
+        
+      items = sortReviewItems(items: items, services: services)
+
+      if Settings.reviewItemsLimitEnabled && items.count > Settings.reviewItemsLimit {
+        print("Truncating \(items.count) review items to \(Settings.reviewItemsLimit)")
+        items = Array(items[0 ..< Int(Settings.reviewItemsLimit)])
       }
 
       let vc = segue.destination as! ReviewContainerViewController

--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -46,13 +46,7 @@ class ReviewSession {
       Settings.ankiModeCombineReadingMeaning) || self.isPracticeSession {
       activeQueueSize = 1
     } else {
-      activeQueueSize = Int(Settings.reviewBatchSize)
-    }
-
-    sortReviewQueue()
-
-    if Settings.reviewItemsLimitEnabled, reviewQueue.count > Settings.reviewItemsLimit {
-      reviewQueue = Array(reviewQueue[0 ..< Int(Settings.reviewItemsLimit)])
+      activeQueueSize = reviewQueue.count
     }
 
     refillActiveQueue()
@@ -226,97 +220,6 @@ class ReviewSession {
     }
     activeStudyMaterials!.meaningSynonyms.append(text)
     _ = services.localCachingClient?.updateStudyMaterial(activeStudyMaterials!)
-  }
-
-  private func sortReviewQueue() {
-    reviewQueue.shuffle()
-    switch Settings.reviewOrder {
-    case .ascendingSRSStage:
-      reviewQueue.sort { (a, b: ReviewItem) -> Bool in
-        if a.assignment.srsStage < b.assignment.srsStage { return true }
-        if a.assignment.srsStage > b.assignment.srsStage { return false }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
-        return false
-      }
-    case .descendingSRSStage:
-      reviewQueue.sort { (a, b: ReviewItem) -> Bool in
-        if a.assignment.srsStage < b.assignment.srsStage { return false }
-        if a.assignment.srsStage > b.assignment.srsStage { return true }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
-        return false
-      }
-    case .currentLevelFirst:
-      reviewQueue.sort { (a, b: ReviewItem) -> Bool in
-        if a.assignment.level < b.assignment.level { return false }
-        if a.assignment.level > b.assignment.level { return true }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
-        return false
-      }
-    case .lowestLevelFirst:
-      reviewQueue.sort { (a, b: ReviewItem) -> Bool in
-        if a.assignment.level < b.assignment.level { return true }
-        if a.assignment.level > b.assignment.level { return false }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
-        return false
-      }
-    case .newestAvailableFirst:
-      reviewQueue.sort { (a, b: ReviewItem) -> Bool in
-        if a.assignment.availableAt < b.assignment.availableAt { return false }
-        if a.assignment.availableAt > b.assignment.availableAt { return true }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
-        return false
-      }
-    case .oldestAvailableFirst:
-      reviewQueue.sort { (a, b: ReviewItem) -> Bool in
-        if a.assignment.availableAt < b.assignment.availableAt { return true }
-        if a.assignment.availableAt > b.assignment.availableAt { return false }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
-        return false
-      }
-    case .longestRelativeWait:
-      reviewQueue.sort { (a, b: ReviewItem) -> Bool in
-        if availableRatio(a.assignment) < availableRatio(b.assignment) { return false }
-        if availableRatio(a.assignment) > availableRatio(b.assignment) { return true }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
-        return false
-      }
-    case .alternatingSRSStage:
-      reviewQueue.sort { (a, b: ReviewItem) -> Bool in
-        if a.assignment.srsStage < b.assignment.srsStage { return true }
-        if a.assignment.srsStage > b.assignment.srsStage { return false }
-        if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
-        if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
-        return false
-      }
-      var alternatingReviewQueue = [ReviewItem]()
-      var highest = false
-      while reviewQueue.count > 0 {
-        alternatingReviewQueue
-          .append(highest ? reviewQueue.removeLast() : reviewQueue.removeFirst())
-        highest = !highest
-      }
-      reviewQueue = alternatingReviewQueue
-    case .random:
-      break
-
-    @unknown default:
-      fatalError()
-    }
-  }
-
-  private func availableRatio(_ assignment: TKMAssignment) -> TimeInterval {
-    let truncatedDate =
-      Date(timeIntervalSince1970: Double((Int(Date().timeIntervalSince1970) / 3600) * 3600))
-    let subject = services.localCachingClient.getSubject(id: assignment.subjectID)!
-    return truncatedDate.timeIntervalSince(assignment.availableAtDate) / assignment.srsStage
-      .duration(subject)
   }
 
   private func refillActiveQueue() {

--- a/ios/ReviewUtils.swift
+++ b/ios/ReviewUtils.swift
@@ -1,0 +1,116 @@
+// Copyright 2025 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import WaniKaniAPI
+
+func sortReviewItems(items: [ReviewItem], services: TKMServices) -> [ReviewItem] {
+  var reviewQueue: [ReviewItem] = items
+  reviewQueue.shuffle()
+  switch Settings.reviewOrder {
+  case .ascendingSRSStage:
+    reviewQueue.sort { (a, b: ReviewItem) -> Bool in
+      if a.assignment.srsStage < b.assignment.srsStage { return true }
+      if a.assignment.srsStage > b.assignment.srsStage { return false }
+      if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
+      if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+      return false
+    }
+  case .descendingSRSStage:
+    reviewQueue.sort { (a, b: ReviewItem) -> Bool in
+      if a.assignment.srsStage < b.assignment.srsStage { return false }
+      if a.assignment.srsStage > b.assignment.srsStage { return true }
+      if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
+      if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+      return false
+    }
+  case .currentLevelFirst:
+    reviewQueue.sort { (a, b: ReviewItem) -> Bool in
+      if a.assignment.level < b.assignment.level { return false }
+      if a.assignment.level > b.assignment.level { return true }
+      if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
+      if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+      return false
+    }
+  case .lowestLevelFirst:
+    reviewQueue.sort { (a, b: ReviewItem) -> Bool in
+      if a.assignment.level < b.assignment.level { return true }
+      if a.assignment.level > b.assignment.level { return false }
+      if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
+      if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+      return false
+    }
+  case .newestAvailableFirst:
+    reviewQueue.sort { (a, b: ReviewItem) -> Bool in
+      if a.assignment.availableAt < b.assignment.availableAt { return false }
+      if a.assignment.availableAt > b.assignment.availableAt { return true }
+      if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
+      if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+      return false
+    }
+  case .oldestAvailableFirst:
+    reviewQueue.sort { (a, b: ReviewItem) -> Bool in
+      if a.assignment.availableAt < b.assignment.availableAt { return true }
+      if a.assignment.availableAt > b.assignment.availableAt { return false }
+      if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
+      if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+      return false
+    }
+  case .longestRelativeWait:
+    reviewQueue.sort { (a, b: ReviewItem) -> Bool in
+      if availableRatio(a.assignment, services: services) < availableRatio(b.assignment,
+                                                                           services: services) {
+        return false
+      }
+      if availableRatio(a.assignment, services: services) > availableRatio(b.assignment,
+                                                                           services: services) {
+        return true
+      }
+      if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
+      if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+      return false
+    }
+  case .alternatingSRSStage:
+    reviewQueue.sort { (a, b: ReviewItem) -> Bool in
+      if a.assignment.srsStage < b.assignment.srsStage { return true }
+      if a.assignment.srsStage > b.assignment.srsStage { return false }
+      if a.assignment.subjectType.rawValue < b.assignment.subjectType.rawValue { return true }
+      if a.assignment.subjectType.rawValue > b.assignment.subjectType.rawValue { return false }
+      return false
+    }
+    var alternatingReviewQueue = [ReviewItem]()
+    var highest = false
+    while reviewQueue.count > 0 {
+      alternatingReviewQueue
+        .append(highest ? reviewQueue.removeLast() : reviewQueue.removeFirst())
+      highest = !highest
+    }
+    reviewQueue = alternatingReviewQueue
+  case .random:
+    break
+
+  @unknown default:
+    fatalError()
+  }
+  return reviewQueue
+}
+
+private func availableRatio(_ assignment: TKMAssignment, services: TKMServices) -> TimeInterval {
+  let truncatedDate =
+    Date(timeIntervalSince1970: Double((Int(Date().timeIntervalSince1970) / 3600) * 3600))
+  let subject = services.localCachingClient.getSubject(id: assignment.subjectID)!
+  return truncatedDate.timeIntervalSince(assignment.availableAtDate)
+    / assignment.srsStage
+    .duration(subject)
+}


### PR DESCRIPTION
see #823 for background. Sorting the review queue inside the review session component causes everything that uses the reviewSession component (lessons, burned items, leeches, etc) gets truncated when we really just want to truncate the review session only

instead of sorting inside the review session component, sort when initializing the component from the main component

this was caused by #801 

closes #823

# Review session is now 16 items in length, as expected
<img width="554" alt="Screenshot 2025-03-31 at 12 26 12 PM" src="https://github.com/user-attachments/assets/589b3b1d-68fb-4434-81dd-8b221d188252" />

