### PR TITLE
allow skipping kanji readings

### DIFF
--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -176,9 +176,12 @@ class ReviewSession {
     }
 
     // Remove it from the active queue if that was the last part.
+    let shouldIgnoreReading: Bool = activeSubject.hasKanji && Settings.skipKanjiReadings
+    let answeredReading: Bool = activeTask.answeredReading || activeSubject
+      .readings.isEmpty
     let isSubjectFinished =
       (activeTask.answeredMeaning || activeSubject.meanings.isEmpty) &&
-      (activeTask.answeredReading || activeSubject.readings.isEmpty)
+      (shouldIgnoreReading || answeredReading)
     let didLevelUp = (!activeTask.answer.readingWrong && !activeTask.answer
       .meaningWrong && !isPracticeSession)
     let newSrsStage =

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -192,6 +192,7 @@ protocol SettingProtocol {
   @Setting(1.0, #keyPath(fontSize)) static var fontSize: Float
   @Setting(false, #keyPath(exactMatch)) static var exactMatch: Bool
   @Setting(true, #keyPath(enableCheats)) static var enableCheats: Bool
+  @Setting(false, #keyPath(skipKanjiReadings)) static var skipKanjiReadings: Bool
   @Setting(true, #keyPath(showOldMnemonic)) static var showOldMnemonic: Bool
   @Setting(true, #keyPath(blurContextSentences)) static var blurContextSentences: Bool
   @Setting(false, #keyPath(useKatakanaForOnyomi)) static var useKatakanaForOnyomi: Bool

--- a/ios/SubjectDetailsSettingsViewController.swift
+++ b/ios/SubjectDetailsSettingsViewController.swift
@@ -72,6 +72,12 @@ class SubjectDetailsSettingsViewController: UITableViewController, TKMViewContro
                               on: Settings.showPreviousLevelGraph,
                               switchHandler: levelGraphSwitchChanged))
 
+    model.add(SwitchModelItem(style: .subtitle,
+                              title: "Skip Kanji readings",
+                              subtitle: "Kanji have meanings and readings. When this setting is enabled, you will not be quizzed about Kanji readings during lessons and review sessions.",
+                              on: Settings.skipKanjiReadings,
+                              switchHandler: skipKanjiReadingsSwitchChanged))
+
     self.model = model
     model.reloadTable()
   }
@@ -104,5 +110,9 @@ class SubjectDetailsSettingsViewController: UITableViewController, TKMViewContro
 
   private func levelGraphSwitchChanged(_ switchView: UISwitch) {
     Settings.showPreviousLevelGraph = switchView.isOn
+  }
+
+  private func skipKanjiReadingsSwitchChanged(_ switchView: UISwitch) {
+    Settings.skipKanjiReadings = switchView.isOn
   }
 }

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		79D887472B419609003D8F99 /* String+SHA256Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D887462B419609003D8F99 /* String+SHA256Test.swift */; };
 		79D887482B419672003D8F99 /* String+SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D887442B41949F003D8F99 /* String+SHA256.swift */; };
 		93B59B2A2367AF130097533C /* UpcomingReviewsChartItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B59B292367AF130097533C /* UpcomingReviewsChartItem.swift */; };
+		97A120DF2D9C467100D19CAE /* ReviewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A120DE2D9C467100D19CAE /* ReviewUtils.swift */; };
 		BB0F6B0C216698F800CB1306 /* TKMKanaInputTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BB0F6B0B216698F800CB1306 /* TKMKanaInputTest.m */; };
 		BBE4E32E2172576B003A200E /* FontLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE4E32D2172576B003A200E /* FontLoader.swift */; };
 		C904455D2395DBAE001BC48B /* AnswerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C904455C2395DBAE001BC48B /* AnswerTextField.swift */; };
@@ -432,6 +433,7 @@
 		7E3A3B65C3A0B280B5FF32D3 /* Pods-Tsurukame (App Store screenshots).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tsurukame (App Store screenshots).debug.xcconfig"; path = "Target Support Files/Pods-Tsurukame (App Store screenshots)/Pods-Tsurukame (App Store screenshots).debug.xcconfig"; sourceTree = "<group>"; };
 		82721E7B5A9C5562CC8D3B9B /* Pods-FontScreenshotter.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FontScreenshotter.release.xcconfig"; path = "Target Support Files/Pods-FontScreenshotter/Pods-FontScreenshotter.release.xcconfig"; sourceTree = "<group>"; };
 		93B59B292367AF130097533C /* UpcomingReviewsChartItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingReviewsChartItem.swift; sourceTree = "<group>"; };
+		97A120DE2D9C467100D19CAE /* ReviewUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewUtils.swift; sourceTree = "<group>"; };
 		9CFD97ACE7ABC2C904715D83 /* Pods-Tsurukame-Tsurukame Complication Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tsurukame-Tsurukame Complication Extension.debug.xcconfig"; path = "Target Support Files/Pods-Tsurukame-Tsurukame Complication Extension/Pods-Tsurukame-Tsurukame Complication Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		BB0F6B0B216698F800CB1306 /* TKMKanaInputTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TKMKanaInputTest.m; sourceTree = "<group>"; };
 		BB0F6B10216B333700CB1306 /* TKMKanaInput+Internals.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TKMKanaInput+Internals.h"; sourceTree = "<group>"; };
@@ -632,6 +634,7 @@
 				638EFE3527E8892400D693D0 /* MainTitleView.xib */,
 				63F7F52223D423E9006A31FB /* MainViewController.swift */,
 				63A702162C2DB97D00AB0504 /* MainWaniKaniTabViewController.swift */,
+				97A120DE2D9C467100D19CAE /* ReviewUtils.swift */,
 				63A5598427E433DF00E7BBCB /* NavigationController.swift */,
 				63B63FF627733ABC0098DAAD /* NotificationDispatcher.swift */,
 				63358E9927365FC70013A2AC /* OfflineAudio.swift */,
@@ -1456,6 +1459,7 @@
 				63CBFF2627731B8B0086BA5F /* DownloadViewController.swift in Sources */,
 				63A16786253AD8D200B5BCD6 /* LocalCachingClient.swift in Sources */,
 				63C4EA7A2C267C85003D3C0B /* XCAssets+Generated.swift in Sources */,
+				97A120DF2D9C467100D19CAE /* ReviewUtils.swift in Sources */,
 				63F7F52E23D4C2CA006A31FB /* Audio.swift in Sources */,
 				63391B592779B8BF005CDA72 /* ReviewSettingsViewController.swift in Sources */,
 				93B59B2A2367AF130097533C /* UpcomingReviewsChartItem.swift in Sources */,


### PR DESCRIPTION
# Feature
This pull pull request adds a new feature to settings / reviews that allows you to skip kanji readings in quizzes. **This impacts both reviews and lessons.**

# Background
I personally do not find a lot of value to learning the kanji readings through SRS because a given kanji can have lots of different readings depending on the word it's in.

One such instance for example is `日`, which has different readings in every single word below:
```
日本
七日
休日
日曜日
朝日
```

If you enable the `show all kanji readings` feature, Tsurukame will show you all readings for that kanji
<img width="516" alt="image" src="https://github.com/user-attachments/assets/d251e986-f164-4584-a298-caf58448e1c3" />

However, Wanikani still only accepts `にち` as the "valid" reading for this kanji.

This is kind of an extreme example, since many kanjis really do only have one or two readings, but I have encountered several such examples in my studies to the point where I personally no longer find value in memorizing the "blessed" reading that wanikani wants me to learn. I personally prefer to indirectly learn readings through vocabulary words, and so for quite a while I have been ignoring kanji readings during quizzes and using the existing "allow cheating" feature of the app to skip the reading.

# The setting
The default value of this setting is `false` which means the default behavior of the app will be to quiz kanji readings unless explicitly overridden by the user.

<img width="543" alt="Screenshot 2025-04-01 at 6 07 13 AM" src="https://github.com/user-attachments/assets/0b6d162d-77ae-40aa-8231-77031eed4da7" />

# The behavior
When the setting is enabled, kanji will not ask for readings during quizzes. Vocabulary is unaffected.

![demo3](https://github.com/user-attachments/assets/09cbdc8b-a01b-4845-98ef-61c98203919a)

