### PR TITLE
Re-integrate Settings.reviewBatchSize use

### DIFF
--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -46,7 +46,7 @@ class ReviewSession {
       Settings.ankiModeCombineReadingMeaning) || self.isPracticeSession {
       activeQueueSize = 1
     } else {
-      activeQueueSize = reviewQueue.count
+      activeQueueSize = Int(Settings.reviewBatchSize)
     }
 
     refillActiveQueue()


### PR DESCRIPTION
Reverts a small change in #824 to make sure the active queue size in reviews is correct.

@zjgoodman Could you help me understand why the change in #824 to remove the use of `Settings.reviewBatchSize` was made? The active queue size shouldn't be controlled by the number of reviews, I believe. I did a test, and the limitation for review items still works with the active queue size being set to `Settings.reviewBatchSize`.

Closes #829