### PR TITLE
Add reader with audio playback to context sentences.

### DIFF
--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -360,9 +360,11 @@ class SubjectDetailsView: UITableView, SubjectChipDelegate {
 
     let indexPath = model.add(section: "Context Sentences")
     for sentence in subject.vocabulary.sentences {
-      model.add(ContextSentenceModelItem(sentence, highlightSubject: subject,
-                                         defaultAttributes: defaultStringAttrs(),
-                                         fontSize: kFontSize))
+      let item = ContextSentenceModelItem(sentence, highlightSubject: subject,
+                                          defaultAttributes: defaultStringAttrs(),
+                                          fontSize: kFontSize)
+      item.initReader()
+      model.add(item)
     }
     return indexPath
   }

--- a/ios/Tables/AttributedModelItem.swift
+++ b/ios/Tables/AttributedModelItem.swift
@@ -17,7 +17,7 @@ import Foundation
 private let kEdgeInsets = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
 private let kMinimumHeight: CGFloat = 44
 
-class AttributedModelItem: TableModelItem {
+class AttributedModelItem: NSObject, TableModelItem {
   var text: NSAttributedString
 
   var rightButtonImage: UIImage?


### PR DESCRIPTION
I'm not an expert iOS developer, but I wanted to add a reader that would playback audio for the context sentences. I feel this really helps with remembering the kanji pronunciation from the examples.

My approach was to reuse the existing pattern with the rightButton. I had to add NSObject as a parent object to be able to add the AVSpeechSynthesizerDelegate to ContextSentenceModelCell.

It probably needs a better implementation, but hoping this feature can be considered for a later release. Thanks!