### PR TITLE
Fix bug with "Interrupt background audio"

### DIFF
--- a/ios/ReviewQuickSettings/ReviewQuickSettingsAudioMenu.swift
+++ b/ios/ReviewQuickSettings/ReviewQuickSettingsAudioMenu.swift
@@ -25,7 +25,7 @@ class ReviewQuickSettingsAudioMenu: ReviewQuickSettingsTable {
         Settings.playAudioAutomatically = on
       })
     model.add(CheckmarkModelItem(style: .default, title: "Interrupt background audio",
-                                 on: Settings.playAudioAutomatically) { on in
+                                 on: Settings.interruptBackgroundAudio) { on in
         Settings.interruptBackgroundAudio = on
       })
 


### PR DESCRIPTION
I noticed a bug where toggling the "interrupt background audio" option does not work as expected. This PR fixes that issue