### PR TITLE
feat: exclude items

### DIFF
--- a/ios/Generated/IB-Segues+Generated.swift
+++ b/ios/Generated/IB-Segues+Generated.swift
@@ -23,6 +23,7 @@ internal enum StoryboardSegue {
     case katakanaCharacterPractice
     case settings
     case showAll
+    case showExcluded
     case showLessonPicker
     case showRemaining
     case startAllLeechReviews

--- a/ios/LessonPickerViewController.swift
+++ b/ios/LessonPickerViewController.swift
@@ -47,7 +47,7 @@ class LessonPickerViewController: UITableViewController, SubjectDelegate {
                 "When you've finished selecting items, tap \"Begin\" " +
                 "in the top right to start.")
 
-    let assignments = services.localCachingClient.getAllAssignments()
+    let assignments = services.localCachingClient.getNonExcludedAssignments()
     let items = ReviewItem.readyForLessons(assignments: assignments,
                                            localCachingClient: services.localCachingClient)
     var levels = [Int32: ReviewsForLevel]()

--- a/ios/MainWaniKaniTabViewController.swift
+++ b/ios/MainWaniKaniTabViewController.swift
@@ -230,6 +230,22 @@ class MainWaniKaniTabViewController: UITableViewController {
       }
     }
 
+    let excludedCount = services.localCachingClient.excludedCount()
+    if excludedCount > 0 {
+      let excludedItems = BasicModelItem(style: .value1,
+                                         title: "Excluded items",
+                                         accessoryType: .disclosureIndicator) { [
+        unowned self
+      ] in
+        self
+          .perform(segue: StoryboardSegue.Main.showExcluded,
+                   sender: self)
+      }
+
+      _ = setTableViewCellCount(excludedItems, count: excludedCount)
+      model.add(excludedItems)
+    }
+
     self.model = model
     tableView.reloadData()
   }
@@ -260,7 +276,7 @@ class MainWaniKaniTabViewController: UITableViewController {
   override func prepare(for segue: UIStoryboardSegue, sender _: Any?) {
     switch StoryboardSegue.Main(segue) {
     case .startReviews:
-      let assignments = services.localCachingClient.getAllAssignments()
+      let assignments = services.localCachingClient.getNonExcludedAssignments()
       var items = ReviewItem.readyForReview(assignments: assignments,
                                             localCachingClient: services.localCachingClient)
       if items.count == 0 {
@@ -340,7 +356,7 @@ class MainWaniKaniTabViewController: UITableViewController {
       vc.setup(services: services, items: items, isPracticeSession: true)
 
     case .startLessons:
-      let assignments = services.localCachingClient.getAllAssignments()
+      let assignments = services.localCachingClient.getNonExcludedAssignments()
       var items = ReviewItem.readyForLessons(assignments: assignments,
                                              localCachingClient: services.localCachingClient)
         .shuffled()
@@ -367,6 +383,11 @@ class MainWaniKaniTabViewController: UITableViewController {
     case .showRemaining:
       let vc = segue.destination as! SubjectsRemainingViewController
       vc.setup(services: services, level: selectedSubjectCatalogLevel)
+
+    case .showExcluded:
+      let vc = segue.destination as! SubjectsExcludedViewController
+      vc.setup(services: services, category: selectedSrsStageCategory,
+               showAnswers: Settings.subjectCatalogueViewShowAnswers)
 
     case .tableForecast:
       let vc = segue.destination as! UpcomingReviewsViewController

--- a/ios/Resources/Main.storyboard
+++ b/ios/Resources/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ByY-Kf-IzJ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ByY-Kf-IzJ">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -54,6 +54,7 @@
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startReviews" id="SNd-yz-wla"/>
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startAlreadyPassedApprenticeReviews" id="Zly-NW-0bf"/>
                         <segue destination="pOc-Ig-wgQ" kind="show" identifier="startAllLeechReviews" id="LEs-R7-aHH"/>
+                        <segue destination="5T5-eW-fQb" kind="show" identifier="showExcluded" id="m1H-uD-W8R"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="kbL-0E-6LB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -204,7 +205,7 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="NbY-WF-HHV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-415" y="-1043"/>
+            <point key="canvasLocation" x="-159" y="-1026"/>
         </scene>
         <!--Lessons-->
         <scene sceneID="z1E-IC-jbQ">
@@ -224,7 +225,7 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IjS-jp-gV8" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-420" y="-948"/>
+            <point key="canvasLocation" x="583" y="-1051"/>
         </scene>
         <!--SubjectCatalogue-->
         <scene sceneID="cQS-Qo-ms0">
@@ -255,6 +256,16 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="UAj-ZT-6TK" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-449" y="-1186"/>
+        </scene>
+        <!--SubjectsExcluded-->
+        <scene sceneID="pPD-SX-ZXD">
+            <objects>
+                <viewControllerPlaceholder storyboardIdentifier="subjectsExcluded" storyboardName="SubjectsExcluded" id="5T5-eW-fQb" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="8gE-6x-hCy"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3dR-Vk-0XO" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="605" y="-883"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>

--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -112,6 +112,12 @@ class ReviewSession {
     refillActiveQueue()
   }
 
+  public func excludeTask() {
+    activeQueue.remove(at: activeTaskIndex)
+    activeTask.reset()
+    refillActiveQueue()
+  }
+
   struct MarkResult {
     let subjectFinished: Bool
     let didLevelUp: Bool
@@ -170,6 +176,8 @@ class ReviewSession {
     case .OverrideAnswerCorrect:
       tasksAnsweredCorrectly += 1
 
+    case .Exclude:
+      fatalError()
     case .AskAgainLater:
       // Handled above.
       fatalError()
@@ -223,6 +231,15 @@ class ReviewSession {
     }
     activeStudyMaterials!.meaningSynonyms.append(text)
     _ = services.localCachingClient?.updateStudyMaterial(activeStudyMaterials!)
+  }
+
+  func setExclude(_ exclude: Bool) {
+    if activeStudyMaterials == nil {
+      activeStudyMaterials = TKMStudyMaterials()
+      activeStudyMaterials!.subjectID = activeSubject.id
+    }
+    _ = services.localCachingClient?.setExcluded(studyMaterials: &activeStudyMaterials!,
+                                                 shouldExclude: exclude)
   }
 
   private func refillActiveQueue() {

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -36,6 +36,7 @@ enum AnswerResult {
   case Incorrect
   case OverrideAnswerCorrect
   case AskAgainLater
+  case Exclude
 
   var correct: Bool {
     self == .Correct || self == .OverrideAnswerCorrect
@@ -1101,6 +1102,12 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
       hapticGenerator.impactOccurred()
       hapticGenerator.prepare()
     }
+    if result == .Exclude {
+      // Take the task out of the queue
+      session.excludeTask()
+      randomTask()
+      return
+    }
 
     // Mark the task.
     var marked = session.markAnswer(result, isPracticeSession: isPracticeSession)
@@ -1196,6 +1203,12 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
                               style: .default,
                               handler: { _ in self.askAgain() }))
 
+    if session.activeSubject.subjectType == .vocabulary {
+      c.addAction(UIAlertAction(title: "Exclude this item",
+                                style: .default,
+                                handler: { _ in self.exclude() }))
+    }
+
     if session.activeTaskType == .meaning {
       c.addAction(UIAlertAction(title: "Add synonym",
                                 style: .default,
@@ -1216,6 +1229,11 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
 
   @objc func askAgain() {
     markAnswer(.AskAgainLater)
+  }
+
+  @objc func exclude() {
+    session.setExclude(true)
+    markAnswer(.Exclude)
   }
 
   @objc func addSynonym() {

--- a/ios/SubjectsExcluded.storyboard
+++ b/ios/SubjectsExcluded.storyboard
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cEI-g9-b2L">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Subjects Excluded View Controller-->
+        <scene sceneID="fnM-6Z-i8v">
+            <objects>
+                <tableViewController id="cEI-g9-b2L" customClass="SubjectsExcludedViewController" customModule="Tsurukame" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="rfN-Ga-k6V">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <connections>
+                            <outlet property="dataSource" destination="cEI-g9-b2L" id="2Xr-3N-J4w"/>
+                            <outlet property="delegate" destination="cEI-g9-b2L" id="jRA-ON-37e"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ZUp-vL-P86" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-308" y="-711"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ios/SubjectsExcludedViewController.swift
+++ b/ios/SubjectsExcludedViewController.swift
@@ -1,0 +1,81 @@
+// Copyright 2025 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+import Foundation
+import WaniKaniAPI
+
+class SubjectsExcludedViewController: UITableViewController, SubjectDelegate, TKMViewController {
+  private var services: TKMServices!
+  private var model: TableModel?
+  private var shouldReload: Bool = false
+
+  func setup(services: TKMServices, category _: SRSStageCategory, showAnswers _: Bool) {
+    self.services = services
+  }
+
+  // MARK: - TKMViewController
+
+  var canSwipeToGoBack: Bool { true }
+
+  // MARK: - UIViewController
+
+  func getItems() -> [SubjectModelItem] {
+    var items = [SubjectModelItem]()
+    for assignment in services.localCachingClient.getExcludedAssignments() {
+      guard let subject = services.localCachingClient.getSubject(id: assignment.subjectID)
+      else {
+        continue
+      }
+      let item = SubjectModelItem(subject: subject, delegate: self, assignment: assignment,
+                                  readingWrong: false, meaningWrong: false)
+      item.showLevelNumber = true
+      item.showAnswers = true
+      items.append(item)
+    }
+    return items
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    navigationItem.title = "Excluded items"
+    let model = MutableTableModel(tableView: tableView)
+
+    let exclusions = getItems()
+    model.add(section: "Vocabulary (\(exclusions.count))")
+    for item in exclusions {
+      model.add(item)
+    }
+
+    self.model = model
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    navigationController?.isNavigationBarHidden = false
+    if shouldReload {
+      viewDidLoad()
+    }
+  }
+
+  // MARK: - SubjectDelegate
+
+  func didTapSubject(_ subject: TKMSubject) {
+    shouldReload = true
+    let vc = StoryboardScene.SubjectDetails.initialScene.instantiate()
+    vc.setup(services: services, subject: subject)
+    navigationController?.pushViewController(vc, animated: true)
+  }
+}

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -177,6 +177,8 @@
 		79D887472B419609003D8F99 /* String+SHA256Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D887462B419609003D8F99 /* String+SHA256Test.swift */; };
 		79D887482B419672003D8F99 /* String+SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D887442B41949F003D8F99 /* String+SHA256.swift */; };
 		93B59B2A2367AF130097533C /* UpcomingReviewsChartItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B59B292367AF130097533C /* UpcomingReviewsChartItem.swift */; };
+		9721708A2DBAF247001DFFED /* SubjectsExcludedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 972170892DBAF247001DFFED /* SubjectsExcludedViewController.swift */; };
+		9721708C2DBAF3A6001DFFED /* SubjectsExcluded.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9721708B2DBAF3A6001DFFED /* SubjectsExcluded.storyboard */; };
 		97A120DF2D9C467100D19CAE /* ReviewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A120DE2D9C467100D19CAE /* ReviewUtils.swift */; };
 		BB0F6B0C216698F800CB1306 /* TKMKanaInputTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BB0F6B0B216698F800CB1306 /* TKMKanaInputTest.m */; };
 		BBE4E32E2172576B003A200E /* FontLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE4E32D2172576B003A200E /* FontLoader.swift */; };
@@ -433,6 +435,8 @@
 		7E3A3B65C3A0B280B5FF32D3 /* Pods-Tsurukame (App Store screenshots).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tsurukame (App Store screenshots).debug.xcconfig"; path = "Target Support Files/Pods-Tsurukame (App Store screenshots)/Pods-Tsurukame (App Store screenshots).debug.xcconfig"; sourceTree = "<group>"; };
 		82721E7B5A9C5562CC8D3B9B /* Pods-FontScreenshotter.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FontScreenshotter.release.xcconfig"; path = "Target Support Files/Pods-FontScreenshotter/Pods-FontScreenshotter.release.xcconfig"; sourceTree = "<group>"; };
 		93B59B292367AF130097533C /* UpcomingReviewsChartItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingReviewsChartItem.swift; sourceTree = "<group>"; };
+		972170892DBAF247001DFFED /* SubjectsExcludedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectsExcludedViewController.swift; sourceTree = "<group>"; };
+		9721708B2DBAF3A6001DFFED /* SubjectsExcluded.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SubjectsExcluded.storyboard; sourceTree = "<group>"; };
 		97A120DE2D9C467100D19CAE /* ReviewUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewUtils.swift; sourceTree = "<group>"; };
 		9CFD97ACE7ABC2C904715D83 /* Pods-Tsurukame-Tsurukame Complication Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tsurukame-Tsurukame Complication Extension.debug.xcconfig"; path = "Target Support Files/Pods-Tsurukame-Tsurukame Complication Extension/Pods-Tsurukame-Tsurukame Complication Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		BB0F6B0B216698F800CB1306 /* TKMKanaInputTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TKMKanaInputTest.m; sourceTree = "<group>"; };
@@ -592,6 +596,8 @@
 		630FD60A1FC45BDF00D21C1F = {
 			isa = PBXGroup;
 			children = (
+				9721708B2DBAF3A6001DFFED /* SubjectsExcluded.storyboard */,
+				972170892DBAF247001DFFED /* SubjectsExcludedViewController.swift */,
 				631CAD62234AD5FC008CEA73 /* AnswerChecker.swift */,
 				C904455C2395DBAE001BC48B /* AnswerTextField.swift */,
 				638A5C4D25A471F9001A7AEE /* AppDelegate.swift */,
@@ -1125,6 +1131,7 @@
 				63C4EA782C25993B003D3C0B /* LessonOrder.storyboard in Resources */,
 				63C4EA702C2598A4003D3C0B /* OfflineAudio.storyboard in Resources */,
 				63C4EA6C2C258F2C003D3C0B /* SelectFonts.storyboard in Resources */,
+				9721708C2DBAF3A6001DFFED /* SubjectsExcluded.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1489,6 +1496,7 @@
 				63BEBF9725C57D4000123147 /* SearchResultViewController.swift in Sources */,
 				639CE0BD2CF0ABD500902668 /* FeatureFlags.swift in Sources */,
 				639528FD25CC2F4F009845ED /* LessonOrderViewController.swift in Sources */,
+				9721708A2DBAF247001DFFED /* SubjectsExcludedViewController.swift in Sources */,
 				63E1386827E59F4100AC4706 /* FullRefreshOverlayView.swift in Sources */,
 				633252882727E8A700ABBA04 /* SubjectCatalogueViewController.swift in Sources */,
 				63F7F52C23D43DF6006A31FB /* Services.swift in Sources */,


### PR DESCRIPTION
### Short summary
this PR introduces a feature that allows users to **exclude** items that they don't care about, preventing them from appearing in their review queues

### Background
As I have progressed through wanikani, I have encountered various vocabulary words that I personally do not find value in studying, yet they appear in my review queue. they also contribute to my overall review count's number, which is currently quite high, which discourages me from doing reviews and also makes me feel like I'm not making much progress

![Screenshot 2025-05-05 at 10 11 39 AM](https://github.com/user-attachments/assets/5046343c-5392-4c0a-91cf-cbad7b598d59)

A few examples of such words that I prefer not to study include:
```
金玉 testicles
ナポレオン3世 napoleon the 3rd
ハート形 heart shape
```

Additionally, there exists words that I do find value to learning, but there exist many duplicates of the words that are redundant and annoying to study. For example the counters:
```
~斤 bread loaf
一斤 1 bread loaf
二斤 2 bread loaves

~階 floor
一階 first floor
二階 second floor
四十二階 forty second floor
```

Another situation is words that are essentially the same thing but just stretched into 3 different items
```
消化する to digest
消化 digestion
不良消化 indigestion
```

# New behavior
## Main screen
At the bottom of the main screen under the "all levels" section, I added `excluded items`
![main](https://github.com/user-attachments/assets/750d48ec-b7b7-4df3-a7dd-2daa414842af)

## Excluded items view
When you click on the excluded items on the main screen, you are taken to the excluded items view.
![excluded](https://github.com/user-attachments/assets/72e9efa0-1725-4783-acf2-b01acb30c848)

## Item details view
If you click on a particular item in the excluded items view, you can see the usual item details screen, but now there's a handy slider to toggle whether or not the item should be excluded.
![excluded-details](https://github.com/user-attachments/assets/0f04578a-158e-46d9-9b11-39805355603b)

## From within a review
From within a review, users can exclude items the same way that they can add synonyms or mark their answer as correct.
![review-exclude](https://github.com/user-attachments/assets/87bddec9-91b8-4a19-8be1-7b2035da7cf2)
Note that **Kanji and radicals cannot be excluded**. I decided to make it this way because:
1. This is a kanji learning app. Why would we exclude kanji?
2. If we allow users to exclude kanjis and/or radicals, they could prevent themselves from being able to level up
![kanji](https://github.com/user-attachments/assets/63d4c9b7-3be3-4c5f-866f-bb0e8112a508)

Putting it all together, here's what reviews look like:
![review](https://github.com/user-attachments/assets/47eb42ed-0d96-469c-834b-ab37b1bd58d8)

# Persistence implementation
The way I implemented persistence might be controversial. I wanted to ensure that exclusions are saved across devices, so I decided to hijack the `reading note` field in wanikani to store my metadata in there

Excluded items will contain `#tsurukameExclude` in the note
![wanikani](https://github.com/user-attachments/assets/6c66c0c5-5874-4d16-af49-db5b18396082)

However, tsurukame will hide this text from you to prevent any confusion
![tsurukame-no-note](https://github.com/user-attachments/assets/4e655466-0468-4e82-9be1-cdf4d312aee4)

For users who DO use this field, it's ok! You can still have notes for excluded items (although personally that seems like an unlikely scenario to me. if you excluded the item, why would you write notes for it?):
![wanikani-note](https://github.com/user-attachments/assets/df75b3c4-4bfa-4e78-af3f-a9f16a1f3526)

The note also shows up in tsurukame
![tsurukame-note](https://github.com/user-attachments/assets/1a60142a-0105-41d2-a1fa-256d80089920)
