### PR TITLE
Fix full refresh removing recent mistakes

### DIFF
--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -1479,7 +1479,7 @@ class LocalCachingClient: NSObject, SubjectLevelGetter {
             db
               .mustExecuteUpdate("UPDATE subject_progress SET last_mistake_time = ? WHERE id = ?",
                                  args: [
-                                   item.value,
+                                   self.dateFormatter.string(from: item.value),
                                    item.key,
                                  ])
           }


### PR DESCRIPTION
The `sync` function in `LocalCachingClient` was not formatting recent mistake data correctly when inserting it into the database. Because of this, a full refresh basically erased recent mistake data, although it could later be recovered with an app restart with iCloud mistake syncing. This fix correctly formats the date data when inserting it into the database.

This is a straightforward, simple fix and is ready for review/merge at any time.