### PR TITLE
Adds options for lessonBatchSize to range from 1-10 

### DIFF
--- a/ios/LessonSettingsViewController.swift
+++ b/ios/LessonSettingsViewController.swift
@@ -121,7 +121,9 @@ func makeLessonBatchSizeViewController() -> UIViewController {
                                            title: "Lesson Batch Size",
                                            helpText: "Set the number of new lessons to be " +
                                              "introduced before the quiz session.")
-  vc.addChoicesFromRange(3 ... 10, suffix: " lessons")
+  vc.addChoice(name: "1 lesson", value: 1)
+  vc.addChoicesFromRange(2 ... 10, suffix: " lessons")
+
   return vc
 }
 


### PR DESCRIPTION
## Update lesson batch size choices to include 1 and 2 lessons

Changed the minimum selectable lessons in the batch from 3 to 1 by adding explicit choices for "1 lesson" and "2 lessons". This allows users to pick smaller batch sizes, improving flexibility and enabling better control via user defaults.

### Changes:
- Added `vc.addChoice(name: "1 lesson", value: 1)`
- Updated range to start from 2 (`vc.addChoicesFromRange(2 ... 10, suffix: " lessons")`)

### Motivation:
Previously, the minimum was 3 lessons, which limited user options. Now users can select 1 or 2 lessons, which can help with skipping the lesson picker.
