### PR TITLE
Tweak: exclude items feature

### DIFF
--- a/ios/LessonSettingsViewController.swift
+++ b/ios/LessonSettingsViewController.swift
@@ -66,6 +66,13 @@ class LessonSettingsViewController: UITableViewController, TKMViewController {
         [unowned self] in
         self.showKanaOnlyVocabChanged($0)
       })
+    model.add(SwitchModelItem(style: .subtitle,
+                              title: "Allow excluding vocabulary items",
+                              subtitle: "Allow excluding vocabulary items from lessons, reviews, etc.",
+                              on: Settings.allowExcludeItems) {
+        [unowned self] in
+        self.allowExcludeVocabChanged($0)
+      })
 
     self.model = model
     model.reloadTable()
@@ -98,6 +105,10 @@ class LessonSettingsViewController: UITableViewController, TKMViewController {
 
   private func showKanaOnlyVocabChanged(_ switchView: UISwitch) {
     Settings.showKanaOnlyVocab = switchView.isOn
+  }
+
+  private func allowExcludeVocabChanged(_ switchView: UISwitch) {
+    Settings.allowExcludeItems = switchView.isOn
   }
 
   // MARK: - Tap handlers

--- a/ios/LocalCachingClient.swift
+++ b/ios/LocalCachingClient.swift
@@ -471,7 +471,8 @@ class LocalCachingClient: NSObject, SubjectLevelGetter {
       if assignment.subjectType != .vocabulary {
         return true
       }
-      if let activeStudyMaterials = getStudyMaterial(subjectId: assignment.subjectID) {
+      if Settings.allowExcludeItems,
+         let activeStudyMaterials = getStudyMaterial(subjectId: assignment.subjectID) {
         return !isExcluded(studyMaterials: activeStudyMaterials)
       }
       return true
@@ -703,8 +704,7 @@ class LocalCachingClient: NSObject, SubjectLevelGetter {
     }
 
     // Add fake assignments for any other subjects at this level that don't have assignments yet
-    // (the
-    // user hasn't unlocked the prerequisite radicals/kanji).
+    // (the user hasn't unlocked the prerequisite radicals/kanji).
     let subjectsByLevel = getSubjects(byLevel: level, transaction: db)
     addFakeAssignments(to: &ret, subjectIds: subjectsByLevel.radicals, type: .radical,
                        level: level, excludeSubjectIds: subjectIds)

--- a/ios/MainWaniKaniTabViewController.swift
+++ b/ios/MainWaniKaniTabViewController.swift
@@ -231,7 +231,7 @@ class MainWaniKaniTabViewController: UITableViewController {
     }
 
     let excludedCount = services.localCachingClient.excludedCount()
-    if excludedCount > 0 {
+    if Settings.allowExcludeItems, excludedCount > 0 {
       let excludedItems = BasicModelItem(style: .value1,
                                          title: "Excluded items",
                                          accessoryType: .disclosureIndicator) { [

--- a/ios/MainWaniKaniTabViewController.swift
+++ b/ios/MainWaniKaniTabViewController.swift
@@ -230,20 +230,22 @@ class MainWaniKaniTabViewController: UITableViewController {
       }
     }
 
-    let excludedCount = services.localCachingClient.excludedCount()
-    if Settings.allowExcludeItems, excludedCount > 0 {
-      let excludedItems = BasicModelItem(style: .value1,
-                                         title: "Excluded items",
-                                         accessoryType: .disclosureIndicator) { [
-        unowned self
-      ] in
-        self
-          .perform(segue: StoryboardSegue.Main.showExcluded,
-                   sender: self)
-      }
+    if Settings.allowExcludeItems {
+      let excludedCount = services.localCachingClient.excludedCount()
+      if excludedCount > 0 {
+        let excludedItems = BasicModelItem(style: .value1,
+                                           title: "Excluded items",
+                                           accessoryType: .disclosureIndicator) { [
+          unowned self
+        ] in
+          self
+            .perform(segue: StoryboardSegue.Main.showExcluded,
+                     sender: self)
+        }
 
-      _ = setTableViewCellCount(excludedItems, count: excludedCount)
-      model.add(excludedItems)
+        _ = setTableViewCellCount(excludedItems, count: excludedCount)
+        model.add(excludedItems)
+      }
     }
 
     self.model = model

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1203,7 +1203,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
                               style: .default,
                               handler: { _ in self.askAgain() }))
 
-    if session.activeSubject.subjectType == .vocabulary {
+    if session.activeSubject.subjectType == .vocabulary && Settings.allowExcludeItems {
       c.addAction(UIAlertAction(title: "Exclude this item",
                                 style: .default,
                                 handler: { _ in self.exclude() }))

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -227,4 +227,5 @@ protocol SettingProtocol {
 
   @Setting(true,
            #keyPath(subjectCatalogueViewShowAnswers)) static var subjectCatalogueViewShowAnswers: Bool
+  @Setting(true, #keyPath(allowExcludeItems)) static var allowExcludeItems: Bool
 }

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -624,10 +624,6 @@ class SubjectDetailsView: UITableView, SubjectChipDelegate {
         addShowAllButton(hiddenIndexPaths: [readings, readingExplanation], model: model)
       }
 
-      if optionsShown {
-        _ = addOptions(subject, studyMaterials: studyMaterials, toModel: model)
-      }
-
       // Add context sentences after the Show All button, since they're quite big.
       let contextSentences = addContextSentences(subject, toModel: model)
       if !meaningShown, let contextSentences = contextSentences {
@@ -680,6 +676,10 @@ class SubjectDetailsView: UITableView, SubjectChipDelegate {
        ArtworkManager.contains(subjectID: subject.id) {
       model.add(section: "Artwork by @AmandaBear")
       model.add(ArtworkModelItem(subjectID: subject.id))
+    }
+
+    if optionsShown {
+      _ = addOptions(subject, studyMaterials: studyMaterials, toModel: model)
     }
 
     if FeatureFlags.showSubjectDeveloperOptions {

--- a/ios/SubjectDetailsView.swift
+++ b/ios/SubjectDetailsView.swift
@@ -173,6 +173,8 @@ class SubjectDetailsView: UITableView, SubjectChipDelegate {
     studyMaterialsChanged = false
   }
 
+  // Note: as there is only one option right now, this function is not called if
+  // Settings.allowExcludeItems is false
   private func addOptions(_: TKMSubject,
                           studyMaterials _: TKMStudyMaterials?,
                           toModel model: MutableTableModel) -> IndexPath? {
@@ -538,7 +540,8 @@ class SubjectDetailsView: UITableView, SubjectChipDelegate {
     let readingAttempted = task?.answeredReading == true || task?.answer.readingWrong == true
     let meaningShown = !isReview || meaningAttempted
     let readingShown = !isReview || readingAttempted
-    let optionsShown = !isReview && subject.subjectType == .vocabulary
+    let optionsShown = !isReview && subject.subjectType == .vocabulary && Settings
+      .allowExcludeItems
 
     var meaningNote = ""
     if studyMaterials != nil {


### PR DESCRIPTION
See #836. Some users may not want this feature and/or may want the options to not be so prominent above part of speech/other information when the majority of the time things will remain enabled.

This PR does two things:
* Allows disabling of the exclude items feature in its entirety (keeps any previously-excluded data but pretends like it was never excluded)
* Moves options for excluding items to the bottom of the subject details

CC @zjgoodman 