### PR TITLE
Improved Anki mode

### DIFF
--- a/ios/BottomSheetAction.swift
+++ b/ios/BottomSheetAction.swift
@@ -1,0 +1,269 @@
+// Copyright 2025 David Sansome
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import UIKit
+
+struct BottomSheetAction {
+  let title: String
+  let style: Style
+  let handler: (() -> Void)?
+
+  enum Style {
+    case `default`
+    case destructive
+    case cancel
+  }
+
+  init(title: String, style: Style = .default, handler: (() -> Void)? = nil) {
+    self.title = title
+    self.style = style
+    self.handler = handler
+  }
+}
+
+class BottomSheetViewController: UIViewController {
+  private let actions: [BottomSheetAction]
+  private let sheetTitle: String?
+  private let sheetMessage: String?
+
+  private let containerView = UIView()
+  private let stackView = UIStackView()
+  private let dimmingView = UIView()
+
+  private var containerBottomConstraint: NSLayoutConstraint?
+
+  init(title: String?, message: String?, actions: [BottomSheetAction]) {
+    sheetTitle = title
+    sheetMessage = message
+    self.actions = actions
+    super.init(nibName: nil, bundle: nil)
+    modalPresentationStyle = .overFullScreen
+    modalTransitionStyle = .crossDissolve
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    setupDimmingView()
+    setupContainerView()
+    setupStackView()
+    setupActions()
+  }
+
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    animateIn()
+  }
+
+  private func setupDimmingView() {
+    dimmingView.backgroundColor = .clear
+    dimmingView.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(dimmingView)
+
+    NSLayoutConstraint.activate([
+      dimmingView.topAnchor.constraint(equalTo: view.topAnchor),
+      dimmingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      dimmingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      dimmingView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+    ])
+
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dimmingViewTapped))
+    dimmingView.addGestureRecognizer(tapGesture)
+  }
+
+  private func setupContainerView() {
+    if #available(iOS 13.0, *) {
+      containerView.backgroundColor = .systemBackground
+    } else {
+      containerView.backgroundColor = .white
+    }
+    containerView.layer.cornerRadius = 16
+    containerView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+    containerView.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(containerView)
+
+    containerBottomConstraint = containerView.bottomAnchor.constraint(equalTo: view.bottomAnchor,
+                                                                      constant: 400)
+
+    NSLayoutConstraint.activate([
+      containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      containerBottomConstraint!,
+    ])
+  }
+
+  private func setupStackView() {
+    stackView.axis = .vertical
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    containerView.addSubview(stackView)
+
+    NSLayoutConstraint.activate([
+      stackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 16),
+      stackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+      stackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+      stackView.bottomAnchor.constraint(equalTo: containerView.safeAreaLayoutGuide.bottomAnchor,
+                                        constant: -8),
+    ])
+  }
+
+  private func setupActions() {
+    // Add title if present
+    if let title = sheetTitle, !title.isEmpty {
+      let titleLabel = UILabel()
+      titleLabel.text = title
+      titleLabel.font = .boldSystemFont(ofSize: 13)
+      if #available(iOS 13.0, *) {
+        titleLabel.textColor = .secondaryLabel
+      } else {
+        titleLabel.textColor = .gray
+      }
+      titleLabel.textAlignment = .center
+      titleLabel.numberOfLines = 0
+      stackView.addArrangedSubview(titleLabel)
+
+      let titlePadding = UIView()
+      titlePadding.translatesAutoresizingMaskIntoConstraints = false
+      titlePadding.heightAnchor.constraint(equalToConstant: 4).isActive = true
+      stackView.addArrangedSubview(titlePadding)
+    }
+
+    // Add message if present
+    if let message = sheetMessage, !message.isEmpty {
+      let messageLabel = UILabel()
+      messageLabel.text = message
+      messageLabel.font = .systemFont(ofSize: 13)
+      if #available(iOS 13.0, *) {
+        messageLabel.textColor = .secondaryLabel
+      } else {
+        messageLabel.textColor = .gray
+      }
+      messageLabel.textAlignment = .center
+      messageLabel.numberOfLines = 0
+      stackView.addArrangedSubview(messageLabel)
+
+      let messagePadding = UIView()
+      messagePadding.translatesAutoresizingMaskIntoConstraints = false
+      messagePadding.heightAnchor.constraint(equalToConstant: 16).isActive = true
+      stackView.addArrangedSubview(messagePadding)
+    }
+
+    // Separate cancel action from others
+    let cancelAction = actions.first { $0.style == .cancel }
+    let otherActions = actions.filter { $0.style != .cancel }
+
+    // Add non-cancel actions
+    for (index, action) in otherActions.enumerated() {
+      if index > 0 {
+        let separator = createSeparator()
+        stackView.addArrangedSubview(separator)
+      }
+      let button = createButton(for: action)
+      stackView.addArrangedSubview(button)
+    }
+
+    // Add cancel action at the bottom with extra spacing
+    if let cancel = cancelAction {
+      let spacer = UIView()
+      spacer.translatesAutoresizingMaskIntoConstraints = false
+      spacer.heightAnchor.constraint(equalToConstant: 8).isActive = true
+      if #available(iOS 13.0, *) {
+        spacer.backgroundColor = .systemGroupedBackground
+      } else {
+        spacer.backgroundColor = UIColor(white: 0.95, alpha: 1.0)
+      }
+      stackView.addArrangedSubview(spacer)
+
+      let button = createButton(for: cancel)
+      button.titleLabel?.font = .boldSystemFont(ofSize: 20)
+      stackView.addArrangedSubview(button)
+    }
+  }
+
+  private func createButton(for action: BottomSheetAction) -> UIButton {
+    let button = UIButton(type: .system)
+    button.setTitle(action.title, for: .normal)
+    button.titleLabel?.font = .systemFont(ofSize: 20)
+    button.contentHorizontalAlignment = .center
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.heightAnchor.constraint(equalToConstant: 57).isActive = true
+
+    switch action.style {
+    case .default:
+      button.setTitleColor(.systemBlue, for: .normal)
+    case .destructive:
+      button.setTitleColor(.systemRed, for: .normal)
+    case .cancel:
+      button.setTitleColor(.systemBlue, for: .normal)
+    }
+
+    button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+    button.tag = actions.firstIndex(where: { $0.title == action.title }) ?? 0
+
+    return button
+  }
+
+  @objc private func buttonTapped(_ sender: UIButton) {
+    let action = actions[sender.tag]
+    animateOut {
+      action.handler?()
+    }
+  }
+
+  private func createSeparator() -> UIView {
+    let separator = UIView()
+    if #available(iOS 13.0, *) {
+      separator.backgroundColor = .separator
+    } else {
+      separator.backgroundColor = UIColor(white: 0.8, alpha: 1.0)
+    }
+    separator.translatesAutoresizingMaskIntoConstraints = false
+    separator.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale).isActive = true
+    return separator
+  }
+
+  @objc private func dimmingViewTapped() {
+    // Find and execute cancel action, or just dismiss
+    let cancelAction = actions.first { $0.style == .cancel }
+    animateOut {
+      cancelAction?.handler?()
+    }
+  }
+
+  private func animateIn() {
+    view.layoutIfNeeded()
+    containerBottomConstraint?.constant = 0
+
+    UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut) {
+      self.view.layoutIfNeeded()
+    }
+  }
+
+  private func animateOut(completion: (() -> Void)? = nil) {
+    containerBottomConstraint?.constant = 400
+
+    UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseIn, animations: {
+      self.view.layoutIfNeeded()
+    }) { _ in
+      self.dismiss(animated: false) {
+        completion?()
+      }
+    }
+  }
+}

--- a/ios/ReviewItem.swift
+++ b/ios/ReviewItem.swift
@@ -113,7 +113,7 @@ class ReviewItem: NSObject {
   var answeredReading = false
   var answeredMeaning = false
   var answer = TKMProgress()
-  var skipCount = 0
+  var returnDelay = 0
 
   init(assignment: TKMAssignment, subject: TKMSubject? = nil) {
     self.assignment = assignment

--- a/ios/ReviewItem.swift
+++ b/ios/ReviewItem.swift
@@ -113,6 +113,7 @@ class ReviewItem: NSObject {
   var answeredReading = false
   var answeredMeaning = false
   var answer = TKMProgress()
+  var skipCount = 0
 
   init(assignment: TKMAssignment, subject: TKMSubject? = nil) {
     self.assignment = assignment

--- a/ios/ReviewItem.swift
+++ b/ios/ReviewItem.swift
@@ -148,6 +148,11 @@ class ReviewItem: NSObject {
     return assignment.subjectID <= other.assignment.subjectID
   }
 
+  func hasAttempts() -> Bool {
+    answer.hasMeaningWrong || answer.hasReadingWrong ||
+      answeredMeaning || answeredReading
+  }
+
   func reset() {
     answer.clearMeaningWrong()
     answer.clearReadingWrong()

--- a/ios/ReviewQuickSettings/ReviewContainerViewController.swift
+++ b/ios/ReviewQuickSettings/ReviewContainerViewController.swift
@@ -102,7 +102,7 @@ class ReviewContainerViewController: MMDrawerController, ReviewViewControllerDel
   }
 
   func endReviewSession(button: UIView) {
-    if reviewVC.tasksAnsweredCorrectly == 0 {
+    if reviewVC.tasksAnsweredCorrectly == 0 || !reviewVC.canWrapUp {
       navigationController?.popToRootViewController(animated: true)
       return
     }
@@ -118,6 +118,10 @@ class ReviewContainerViewController: MMDrawerController, ReviewViewControllerDel
     })
     ac.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
     present(ac, animated: true)
+  }
+
+  func canWrapUp() -> Bool {
+    reviewVC.canWrapUp
   }
 
   func wrapUp() {

--- a/ios/ReviewQuickSettings/ReviewQuickSettingsMenu.swift
+++ b/ios/ReviewQuickSettings/ReviewQuickSettingsMenu.swift
@@ -21,6 +21,7 @@ protocol ReviewQuickSettingsMenuDelegate: AnyObject {
   func endReviewSession(button: UIView)
   func wrapUp()
   func wrapUpCount() -> Int
+  func canWrapUp() -> Bool
 }
 
 class ReviewQuickSettingsMenu: ReviewQuickSettingsTable {
@@ -62,16 +63,18 @@ class ReviewQuickSettingsMenu: ReviewQuickSettingsTable {
     endItem!.image = Asset.baselineCancelBlack24pt.image
     model.add(endItem!)
 
-    var wrapUpText = "Wrap up"
-    if let wrapUpCount = delegate?.wrapUpCount(), wrapUpCount != 0 {
-      wrapUpText = "Wrap up (\(wrapUpCount) to go)"
-    }
+    if delegate?.canWrapUp() ?? false {
+      var wrapUpText = "Wrap up"
+      if let wrapUpCount = delegate?.wrapUpCount(), wrapUpCount != 0 {
+        wrapUpText = "Wrap up (\(wrapUpCount) to go)"
+      }
 
-    let wrapUp = BasicModelItem(style: .default, title: wrapUpText) { [weak self] in
-      self?.delegate?.wrapUp()
+      let wrapUp = BasicModelItem(style: .default, title: wrapUpText) { [weak self] in
+        self?.delegate?.wrapUp()
+      }
+      wrapUp.image = Asset.baselineAccessTimeBlack24pt.image
+      model.add(wrapUp)
     }
-    wrapUp.image = Asset.baselineAccessTimeBlack24pt.image
-    model.add(wrapUp)
 
     self.model = model
     model.reloadTable()

--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -43,7 +43,8 @@ class ReviewSession {
     self.isPracticeSession = isPracticeSession
 
     if Settings.groupMeaningReading || (Settings.ankiMode &&
-      Settings.ankiModeCombineReadingMeaning) || self.isPracticeSession {
+      Settings.ankiModeCombineReadingMeaning && Settings.ankiModeTaskType == .both) || self
+      .isPracticeSession {
       activeQueueSize = 1
     } else {
       activeQueueSize = Int(Settings.reviewBatchSize)
@@ -98,7 +99,8 @@ class ReviewSession {
     } else if activeTask.answeredReading || activeSubject.readings.isEmpty {
       activeTaskType = .meaning
     } else if Settings.groupMeaningReading || (Settings.ankiMode &&
-      Settings.ankiModeCombineReadingMeaning) || isPracticeSession {
+      Settings.ankiModeCombineReadingMeaning && Settings.ankiModeTaskType == .both) ||
+      isPracticeSession {
       activeTaskType = Settings.meaningFirst ? .meaning : .reading
     } else {
       activeTaskType = TaskType.random()

--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -38,9 +38,7 @@ class ReviewSession {
   public var wrappingUp: Bool = false {
     didSet {
       if wrappingUp, let task = activeTask {
-        let hasAttempts = task.answer.hasMeaningWrong || task.answer.hasReadingWrong ||
-          task.answeredMeaning || task.answeredReading
-        if !hasAttempts, let index = activeQueue.firstIndex(where: { $0 === task }) {
+        if !task.hasAttempts(), let index = activeQueue.firstIndex(where: { $0 === task }) {
           activeQueue.remove(at: index)
           reviewQueue.append(task)
         }
@@ -88,9 +86,7 @@ class ReviewSession {
       return false
     }
     for item in activeQueue {
-      let hasAttempts = item.answer.hasMeaningWrong || item.answer.hasReadingWrong ||
-        item.answeredMeaning || item.answeredReading
-      if hasAttempts {
+      if item.hasAttempts() {
         return true
       }
     }
@@ -103,7 +99,7 @@ class ReviewSession {
 
   public func nextTask() {
     guard !activeQueue.isEmpty else {
-      return 
+      return
     }
 
     if Settings.groupMeaningReading || isPracticeSession,

--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -35,7 +35,18 @@ class ReviewSession {
   public private(set) var tasksAnswered = 0
   public private(set) var reviewsCompleted = 0
 
-  public var wrappingUp: Bool = false
+  public var wrappingUp: Bool = false {
+    didSet {
+      if wrappingUp, let task = activeTask {
+        let hasAttempts = task.answer.hasMeaningWrong || task.answer.hasReadingWrong ||
+          task.answeredMeaning || task.answeredReading
+        if !hasAttempts, let index = activeQueue.firstIndex(where: { $0 === task }) {
+          activeQueue.remove(at: index)
+          reviewQueue.append(task)
+        }
+      }
+    }
+  }
 
   init(services: TKMServices, items: [ReviewItem], isPracticeSession: Bool = false) {
     self.services = services
@@ -92,7 +103,7 @@ class ReviewSession {
 
   public func nextTask() {
     guard !activeQueue.isEmpty else {
-      return
+      return 
     }
 
     if Settings.groupMeaningReading || isPracticeSession,

--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -105,13 +105,13 @@ class ReviewSession {
     if Settings.groupMeaningReading || isPracticeSession,
        activeTask != nil,
        !activeTask.answeredMeaning || !activeTask.answeredReading,
-       activeTask.skipCount == 0,
+       activeTask.returnDelay == 0,
        let taskIndex = activeQueue.firstIndex(where: { $0 === activeTask }) {
       // Stay on current task for back-to-back after correct answer
       activeTaskIndex = taskIndex
     } else {
       // Normal mode: find eligible tasks or pull from reviewQueue
-      var eligibleIndices = activeQueue.indices.filter { activeQueue[$0].skipCount == 0 }
+      var eligibleIndices = activeQueue.indices.filter { activeQueue[$0].returnDelay == 0 }
       if eligibleIndices.isEmpty, !wrappingUp, !reviewQueue.isEmpty {
         let item = reviewQueue.removeFirst()
         activeQueue.append(item)
@@ -122,8 +122,8 @@ class ReviewSession {
 
       // Decrement skip counts for all items
       for i in activeQueue.indices {
-        if activeQueue[i].skipCount > 0 {
-          activeQueue[i].skipCount -= 1
+        if activeQueue[i].returnDelay > 0 {
+          activeQueue[i].returnDelay -= 1
         }
       }
 
@@ -218,15 +218,16 @@ class ReviewSession {
     case .Correct:
       tasksAnswered += 1
       tasksAnsweredCorrectly += 1
-      activeTask.skipCount = 0
+      activeTask.returnDelay = 0
 
     case .Incorrect:
       tasksAnswered += 1
-      activeTask.skipCount = 5
+      // show this number of items before repeating this one:
+      activeTask.returnDelay = 5
 
     case .OverrideAnswerCorrect:
       tasksAnsweredCorrectly += 1
-      activeTask.skipCount = 0
+      activeTask.returnDelay = 0
 
     case .Exclude:
       fatalError()

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -265,6 +265,10 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     session.activeQueueLength
   }
 
+  public var canWrapUp: Bool {
+    session.canWrapUp
+  }
+
   public var tasksAnsweredCorrectly: Int {
     session.tasksAnsweredCorrectly
   }

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -437,6 +437,9 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
 
   private func keyboardWillHide() {
     subjectDetailsView.contentInset = .zero
+    answerFieldToBottomConstraint.constant = 0
+    questionLabelBottomConstraint.constant = 0
+    previousKeyboardInsetHeight = nil
   }
 
   private func resizeKeyboard(toHeight height: Double) {
@@ -785,7 +788,7 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
     // here so it's in sync with the others.
     answerField.isEnabled = !shown && !isAnkiModeActiveForCurrentTask
     if updateFirstResponder {
-      if !shown {
+      if !shown, !isAnkiModeActiveForCurrentTask {
         answerField.becomeFirstResponder()
       } else {
         answerField.resignFirstResponder()

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1003,6 +1003,9 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
       session.wrappingUp = newValue
       wrapUpIcon.isHidden = !newValue
       wrapUpLabel.isHidden = !newValue
+      if newValue {
+        randomTask()
+      }
     }
   }
 

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -316,6 +316,11 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
       UITapGestureRecognizer(target: self, action: #selector(didShortPressQuestionLabel))
     questionBackground.addGestureRecognizer(shortPressRecognizer)
 
+    let mainViewTapRecognizer =
+      UITapGestureRecognizer(target: self, action: #selector(didTapAnswerArea))
+    mainViewTapRecognizer.cancelsTouchesInView = false
+    view.addGestureRecognizer(mainViewTapRecognizer)
+
     let leftSwipeRecognizer = UISwipeGestureRecognizer(target: self,
                                                        action: #selector(didSwipeQuestionLabel))
     leftSwipeRecognizer.direction = .left
@@ -917,6 +922,20 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
   @objc func didShortPressQuestionLabel(_: UITapGestureRecognizer) {
     toggleFont()
     if isAnkiModeActiveForCurrentTask {
+      if !isAnimatingSubjectDetailsView { submit() }
+      else { ankiModeCachedSubmit = true }
+    }
+  }
+
+  @objc func didTapAnswerArea(_ recognizer: UITapGestureRecognizer) {
+    if isAnkiModeActiveForCurrentTask {
+      // Ignore taps in the top portion of the screen (menu area)
+      let location = recognizer.location(in: view)
+      let topSafeArea = view.safeAreaInsets.top
+      if location.y < topSafeArea + 100 { // 100pt buffer for menu button area
+        return
+      }
+
       if !isAnimatingSubjectDetailsView { submit() }
       else { ankiModeCachedSubmit = true }
     }

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1201,11 +1201,13 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
   // MARK: - Ignoring incorrect answers
 
   @IBAction func addSynonymButtonPressed(_: Any) {
-    let c = UIAlertController(title: "Ignore incorrect answer?",
-                              message:
-                              "Don't cheat!  Only use this if you promise you " +
-                                "knew the correct answer.",
-                              preferredStyle: .actionSheet)
+    let c =
+      UIAlertController(title: isAnkiModeActiveForCurrentTask ? nil : "Ignore incorrect answer?",
+                        message:
+                        isAnkiModeActiveForCurrentTask ? nil :
+                          ("Don't cheat!  Only use this if you promise you " +
+                            "knew the correct answer."),
+                        preferredStyle: .actionSheet)
     c.popoverPresentationController?.sourceView = addSynonymButton
     c.popoverPresentationController?.sourceRect = addSynonymButton.bounds
 

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -943,6 +943,17 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
         return
       }
 
+      // Ignore taps on interactive elements (previous subject button, audio buttons, etc.)
+      if let hitView = view.hitTest(location, with: nil), hitView !== view {
+        var current: UIView? = hitView
+        while let v = current, v !== view, v !== questionBackground {
+          if v is UIControl || v.gestureRecognizers?.isEmpty == false {
+            return
+          }
+          current = v.superview
+        }
+      }
+
       if !isAnimatingSubjectDetailsView { submit() }
       else { ankiModeCachedSubmit = true }
     }

--- a/ios/ReviewViewController.swift
+++ b/ios/ReviewViewController.swift
@@ -1168,8 +1168,9 @@ class ReviewViewController: UIViewController, UITextFieldDelegate, SubjectDelega
         marked = session.markAnswer(.Correct, isPracticeSession: isPracticeSession)
       }
 
-      if Settings.playAudioAutomatically, session.activeTaskType == .reading,
+      if Settings.playAudioAutomatically,
          let subject = session.activeSubject,
+         session.activeTaskType == .reading || subject.readings.isEmpty,
          subject.hasVocabulary, !subject.vocabulary.audio.isEmpty {
         services.audio.play(subjectID: subject.id, delegate: nil)
       }

--- a/ios/Settings.swift
+++ b/ios/Settings.swift
@@ -57,6 +57,20 @@ typealias SettingEnum = CaseIterable & Codable & CustomStringConvertible & RawRe
   }
 }
 
+@objc enum AnkiModeTaskType: UInt, SettingEnum {
+  case both = 1
+  case readingOnly = 2
+  case meaningOnly = 3
+
+  var description: String {
+    switch self {
+    case .both: return "Both"
+    case .readingOnly: return "Reading only"
+    case .meaningOnly: return "Meaning only"
+    }
+  }
+}
+
 private func setArchiveData<T: Codable>(_ object: T, key: String) {
   var data: Data!
   if #available(iOS 11.0, *) {
@@ -204,6 +218,8 @@ protocol SettingProtocol {
   @Setting(false, #keyPath(allowSkippingReviews)) static var allowSkippingReviews: Bool
   @Setting(true, #keyPath(minimizeReviewPenalty)) static var minimizeReviewPenalty: Bool
   @Setting(false, #keyPath(ankiMode)) static var ankiMode: Bool
+  @EnumSetting(AnkiModeTaskType.both,
+               #keyPath(ankiModeTaskType)) static var ankiModeTaskType: AnkiModeTaskType
   @Setting(false,
            #keyPath(ankiModeCombineReadingMeaning)) static var ankiModeCombineReadingMeaning: Bool
   @Setting(true, #keyPath(showPreviousLevelGraph)) static var showPreviousLevelGraph: Bool

--- a/ios/Tsurukame.xcodeproj/project.pbxproj
+++ b/ios/Tsurukame.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		79D887472B419609003D8F99 /* String+SHA256Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D887462B419609003D8F99 /* String+SHA256Test.swift */; };
 		79D887482B419672003D8F99 /* String+SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D887442B41949F003D8F99 /* String+SHA256.swift */; };
 		93B59B2A2367AF130097533C /* UpcomingReviewsChartItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B59B292367AF130097533C /* UpcomingReviewsChartItem.swift */; };
+		96A335072EEF5F800017BC70 /* BottomSheetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A335062EEF5F800017BC70 /* BottomSheetAction.swift */; };
 		9721708A2DBAF247001DFFED /* SubjectsExcludedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 972170892DBAF247001DFFED /* SubjectsExcludedViewController.swift */; };
 		9721708C2DBAF3A6001DFFED /* SubjectsExcluded.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9721708B2DBAF3A6001DFFED /* SubjectsExcluded.storyboard */; };
 		97A120DF2D9C467100D19CAE /* ReviewUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A120DE2D9C467100D19CAE /* ReviewUtils.swift */; };
@@ -435,6 +436,7 @@
 		7E3A3B65C3A0B280B5FF32D3 /* Pods-Tsurukame (App Store screenshots).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tsurukame (App Store screenshots).debug.xcconfig"; path = "Target Support Files/Pods-Tsurukame (App Store screenshots)/Pods-Tsurukame (App Store screenshots).debug.xcconfig"; sourceTree = "<group>"; };
 		82721E7B5A9C5562CC8D3B9B /* Pods-FontScreenshotter.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FontScreenshotter.release.xcconfig"; path = "Target Support Files/Pods-FontScreenshotter/Pods-FontScreenshotter.release.xcconfig"; sourceTree = "<group>"; };
 		93B59B292367AF130097533C /* UpcomingReviewsChartItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingReviewsChartItem.swift; sourceTree = "<group>"; };
+		96A335062EEF5F800017BC70 /* BottomSheetAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetAction.swift; sourceTree = "<group>"; };
 		972170892DBAF247001DFFED /* SubjectsExcludedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectsExcludedViewController.swift; sourceTree = "<group>"; };
 		9721708B2DBAF3A6001DFFED /* SubjectsExcluded.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SubjectsExcluded.storyboard; sourceTree = "<group>"; };
 		97A120DE2D9C467100D19CAE /* ReviewUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewUtils.swift; sourceTree = "<group>"; };
@@ -596,6 +598,7 @@
 		630FD60A1FC45BDF00D21C1F = {
 			isa = PBXGroup;
 			children = (
+				96A335062EEF5F800017BC70 /* BottomSheetAction.swift */,
 				9721708B2DBAF3A6001DFFED /* SubjectsExcluded.storyboard */,
 				972170892DBAF247001DFFED /* SubjectsExcludedViewController.swift */,
 				631CAD62234AD5FC008CEA73 /* AnswerChecker.swift */,
@@ -1437,6 +1440,7 @@
 				63ED9A0F2725037200937944 /* EditableTextModelItem.swift in Sources */,
 				C92AB96F237F280300F79904 /* WatchHelper.swift in Sources */,
 				63D2DAEE275C5D4100D5F6FF /* UIControl+addAction.swift in Sources */,
+				96A335072EEF5F800017BC70 /* BottomSheetAction.swift in Sources */,
 				63F7F51F23D3F335006A31FB /* ReadingModelItem.swift in Sources */,
 				E881943F2A6BC38A002C2E1C /* ArtworkManager.swift in Sources */,
 				633AFAE62352B6F2004F732F /* VocabularyHighlighter.swift in Sources */,


### PR DESCRIPTION
New Anki-mode options and other QOL improvements:

- Allow anki-mode for only readings or only meanings
- Remove popup text that isn't relevant for anki mode
- Clicking anywhere shows answer in anki mode
- Incorrect answers come back 5 questions later instead of immediately (could be a setting)
- Don't show a warning for ending session if there are no half-done reviews
- Don't show 'wrap-up' option if there are no half-done reviews
- When starting wrap-up, go directly to half-done reviews (skip current item if not started)
- Implement custom dialog in iphone because new SDKs put the popup on top of the answer

These changes are a big improvement when using Anki mode, improving UX and making reviews faster