### PR TITLE
Switch AVAudioSession category to .ambient

### DIFF
--- a/ios/Audio.swift
+++ b/ios/Audio.swift
@@ -42,7 +42,7 @@ class Audio: NSObject {
     // Set the audio session category.
     let session = AVAudioSession.sharedInstance()
     try? session
-      .setCategory(.playback,
+      .setCategory(.ambient,
                    options: Settings
                      .interruptBackgroundAudio ? [
                        .duckOthers,


### PR DESCRIPTION
See #865.

Figured I'd open the PR anyway, to make it easier for someone to one-click merge in if you agree :D.

Per https://developer.apple.com/documentation/avfaudio/avaudiosession/category-swift.struct, `.ambient` is "The category for an app in which sound playback is nonprimary — that is, your app also works with the sound turned off." while `.playback` is "The category for playing recorded music or other sounds that are central to the successful use of your app.".

`.ambient` is specifically more appropriate here for the usecase I described — if someone is in public and has the system-level mute switch on, their expectation will be that Tsurukame does not autoplay voice clips.