### PR TITLE
Fix card being skipped instead of retried after incorrect answer in groupMeaningReading mode

### DIFF
--- a/ios/ReviewSession.swift
+++ b/ios/ReviewSession.swift
@@ -222,8 +222,11 @@ class ReviewSession {
 
     case .Incorrect:
       tasksAnswered += 1
-      // show this number of items before repeating this one:
-      activeTask.returnDelay = 5
+      // In groupMeaningReading/practice mode the queue has size 1; setting a delay
+      // would evict the card and pull a new one in, breaking back-to-back retry.
+      if !Settings.groupMeaningReading && !isPracticeSession {
+        activeTask.returnDelay = 5
+      }
 
     case .OverrideAnswerCorrect:
       tasksAnsweredCorrectly += 1


### PR DESCRIPTION
Fixes #883

## What was happening

In `groupMeaningReading` mode, answering a card incorrectly caused it to be skipped and pushed back into the deck rather than shown again for immediate retry. This was a regression introduced by PR #862 ("Improved Anki mode").

## Root cause

PR #862 added two things to `ReviewSession.swift` that conflict with each other in `groupMeaningReading` mode:

1. `returnDelay = 5` on any incorrect answer — intended to make the card reappear after 5 other items.
2. A "stay on current task" block in `nextTask()` that keeps the same card active for back-to-back meaning/reading — but only when `returnDelay == 0`.

The problem: in `groupMeaningReading` mode the active queue has size 1. When `returnDelay = 5` is set after a wrong answer, the card becomes ineligible, `eligibleIndices` is empty, and the code pulls a **new card** from `reviewQueue` to fill the slot. The original card is stranded and reappears much later.

Before PR #862, `nextTask()` simply used `arc4random_uniform(activeQueue.count)`. Since the queue only ever held 1 card in this mode, it always picked the same card — giving the implicit immediate-retry behaviour.

## Fix

Skip the `returnDelay` assignment in `groupMeaningReading` / practice mode. With `returnDelay` staying at `0`, the existing "stay on current task" logic in `nextTask()` correctly keeps the card active for retry:

```swift
case .Incorrect:
  tasksAnswered += 1
  // In groupMeaningReading/practice mode the queue has size 1; setting a delay
  // would evict the card and pull a new one in, breaking back-to-back retry.
  if !Settings.groupMeaningReading && !isPracticeSession {
    activeTask.returnDelay = 5
  }
```

Normal mode (without `groupMeaningReading`) is unaffected — it still gets the 5-item delay on incorrect answers.