### PR TITLE
Stabilize transition between en and jp keyboards

### DIFF
--- a/ios/AnswerTextField.swift
+++ b/ios/AnswerTextField.swift
@@ -30,6 +30,7 @@ class AnswerTextField: UITextField {
     didSet {
       if oldValue != useJapaneseKeyboard {
         if isFirstResponder {
+          // Reload the keyboard if we just changed its language.
           reloadInputViews()
         }
       }

--- a/ios/AnswerTextField.swift
+++ b/ios/AnswerTextField.swift
@@ -29,10 +29,8 @@ class AnswerTextField: UITextField {
   public var useJapaneseKeyboard: Bool = false {
     didSet {
       if oldValue != useJapaneseKeyboard {
-        if self.isFirstResponder {
-          // Reload the keyboard if we just changed its language.
-          self.resignFirstResponder()
-          self.becomeFirstResponder()
+        if isFirstResponder {
+          reloadInputViews()
         }
       }
     }


### PR DESCRIPTION
The newest release introduces a more disruptive dismiss-and-present animation when switching between en and jp keyboards, that was relatively subdued earlier. That answer field is flying all the way down and back up now, creating a really unstable UI experience. 

Changing to reloadInputViews makes the animation more direct keyboard-to-keyboard and keeps the UI in place.

| 1.34 tag in iOS 18.4 sim | Before on iOS 26 sim | PR on iOS 26 sim |
|--------|--------|--------|
| <video src="https://github.com/user-attachments/assets/5b1dcb3c-0216-4f84-b89c-786e2ca3b861" /> | <video src="https://github.com/user-attachments/assets/b975c6e4-7ac2-4d2b-97e5-5300e485fcdb" /> | <video src="https://github.com/user-attachments/assets/cea6241c-5223-4b96-9458-4ae5decb5f19" /> |


